### PR TITLE
docs: Refresh runtime captures and supporting updates ahead of v0.8.0

### DIFF
--- a/.github/linters/typos.toml
+++ b/.github/linters/typos.toml
@@ -1,6 +1,9 @@
 [default.extend-identifiers]
 ScatterND = "ScatterND"
 
+[default.extend-words]
+ba = "ba"
+
 [files]
 extend-exclude = [
   "docs/language-bindings/python-bindings/api-reference/**",

--- a/docs/framework-bindings/tensorflow-bindings.md
+++ b/docs/framework-bindings/tensorflow-bindings.md
@@ -38,14 +38,16 @@ The application should run successfully with:
 
 ```console
 $ ./tf_sample
-2025-03-25 22:13:43.955282: I tensorflow/cc/saved_model/reader.cc:52] Reading meta graph with tags { serve }
-2025-03-25 22:13:43.955340: I tensorflow/cc/saved_model/reader.cc:147] Reading SavedModel debug info (if present) from: lstm2/
-2025-03-25 22:13:43.955394: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
-To enable the following instructions: SSE3 SSE4.1 SSE4.2 AVX AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
-2025-03-25 22:13:44.161071: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:388] MLIR V1 optimization pass is not enabled
-2025-03-25 22:13:44.203364: I tensorflow/cc/saved_model/loader.cc:236] Restoring SavedModel bundle.
-2025-03-25 22:13:44.365220: I tensorflow/cc/saved_model/loader.cc:220] Running initialization op on SavedModel bundle at path: lstm2/
-2025-03-25 22:13:44.499266: I tensorflow/cc/saved_model/loader.cc:462] SavedModel load for tags { serve }; Status: success: OK. Took 593575 microseconds.
+2026-04-29 15:17:17.349003: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
+2026-04-29 15:17:17.361455: I tensorflow/cc/saved_model/reader.cc:83] Reading SavedModel from: lstm2/
+2026-04-29 15:17:17.381109: I tensorflow/cc/saved_model/reader.cc:52] Reading meta graph with tags { serve }
+2026-04-29 15:17:17.381161: I tensorflow/cc/saved_model/reader.cc:147] Reading SavedModel debug info (if present) from: lstm2/
+2026-04-29 15:17:17.381236: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
+To enable the following instructions: SSE3 SSE4.1 SSE4.2 AVX AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
+2026-04-29 15:17:17.481898: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:388] MLIR V1 optimization pass is not enabled
+2026-04-29 15:17:17.506970: I tensorflow/cc/saved_model/loader.cc:236] Restoring SavedModel bundle.
+2026-04-29 15:17:17.598031: I tensorflow/cc/saved_model/loader.cc:220] Running initialization op on SavedModel bundle at path: lstm2/
+2026-04-29 15:17:17.684118: I tensorflow/cc/saved_model/loader.cc:462] SavedModel load for tags { serve }; Status: success: OK. Took 322669 microseconds.
 TF_LoadSessionFromSavedModel OK
 TF_GraphOperationByName serving_default_input_1 is OK
 TF_GraphOperationByName StatefulPartitionedCall is OK
@@ -79,66 +81,65 @@ You can then use the bindings with `LD_PRELOAD`:
 
 ```console
 $ LD_PRELOAD=/usr/local/lib/x86_64-linux-gnu/libvaccel-tf-bindings.so ./tf_sample
-2025.03.25-22:27:30.34 - <debug> Initializing vAccel
-2025.03.25-22:27:30.34 - <info> vAccel 0.6.1-194-19056528
-2025.03.25-22:27:30.34 - <debug> Config:
-2025.03.25-22:27:30.34 - <debug>   plugins = libvaccel-tf.so
-2025.03.25-22:27:30.34 - <debug>   log_level = debug
-2025.03.25-22:27:30.34 - <debug>   log_file = (null)
-2025.03.25-22:27:30.34 - <debug>   profiling_enabled = false
-2025.03.25-22:27:30.34 - <debug>   version_ignore = false
-2025.03.25-22:27:30.34 - <debug> Created top-level rundir: /run/user/1002/vaccel/8IBBqO
-2025.03.25-22:27:30.44 - <info> Registered plugin tf 0.1.0-21-3cb5453e
-2025.03.25-22:27:30.44 - <debug> Registered op tf_session_load from plugin tf
-2025.03.25-22:27:30.44 - <debug> Registered op tf_session_run from plugin tf
-2025.03.25-22:27:30.44 - <debug> Registered op tf_session_delete from plugin tf
-2025.03.25-22:27:30.44 - <debug> Registered op tflite_session_load from plugin tf
-2025.03.25-22:27:30.44 - <debug> Registered op tflite_session_run from plugin tf
-2025.03.25-22:27:30.44 - <debug> Registered op tflite_session_delete from plugin tf
-2025.03.25-22:27:30.44 - <debug> Loaded plugin tf from libvaccel-tf.so
-2025.03.25-22:27:30.45 - <debug> New rundir for session 1: /run/user/1002/vaccel/8IBBqO/session.1
-2025.03.25-22:27:30.45 - <debug> Initialized session 1
-2025.03.25-22:27:30.45 - <warn> Path does not seem to have a `<prefix>://`
-2025.03.25-22:27:30.45 - <warn> Assuming lstm2/ is a local path
-2025.03.25-22:27:30.45 - <debug> Initialized resource 1
-2025.03.25-22:27:30.45 - <debug> session:1 Registered resource 1
-2025.03.25-22:27:30.45 - <debug> session:1 Looking for plugin implementing tf_session_load operation
-2025.03.25-22:27:30.45 - <debug> Returning func from hint plugin tf
-2025.03.25-22:27:30.45 - <debug> Found implementation in tf plugin
-2025.03.25-22:27:30.45 - <debug> [tf] Loading session from SavedModel
-2025-03-25 22:27:30.459234: I tensorflow/cc/saved_model/reader.cc:83] Reading SavedModel from: lstm2/
-2025-03-25 22:27:30.502324: I tensorflow/cc/saved_model/reader.cc:52] Reading meta graph with tags { serve }
-2025-03-25 22:27:30.502381: I tensorflow/cc/saved_model/reader.cc:147] Reading SavedModel debug info (if present) from: lstm2/
-2025-03-25 22:27:30.502437: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
-To enable the following instructions: SSE3 SSE4.1 SSE4.2 AVX AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
-2025-03-25 22:27:30.694945: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:388] MLIR V1 optimization pass is not enabled
-2025-03-25 22:27:30.751997: I tensorflow/cc/saved_model/loader.cc:236] Restoring SavedModel bundle.
-2025-03-25 22:27:30.924794: I tensorflow/cc/saved_model/loader.cc:220] Running initialization op on SavedModel bundle at path: lstm2/
-2025-03-25 22:27:31.080011: I tensorflow/cc/saved_model/loader.cc:462] SavedModel load for tags { serve }; Status: success: OK. Took 620801 microseconds.
-2025.03.25-22:27:31.11 - <debug> Model from path loaded correctly
-2025-03-25 22:27:31.188347: I tensorflow/cc/saved_model/reader.cc:83] Reading SavedModel from: lstm2/
-2025-03-25 22:27:31.236284: I tensorflow/cc/saved_model/reader.cc:52] Reading meta graph with tags { serve }
-2025-03-25 22:27:31.236342: I tensorflow/cc/saved_model/reader.cc:147] Reading SavedModel debug info (if present) from: lstm2/
-2025-03-25 22:27:31.466623: I tensorflow/cc/saved_model/loader.cc:236] Restoring SavedModel bundle.
-2025-03-25 22:27:31.621523: I tensorflow/cc/saved_model/loader.cc:220] Running initialization op on SavedModel bundle at path: lstm2/
-2025-03-25 22:27:31.777220: I tensorflow/cc/saved_model/loader.cc:462] SavedModel load for tags { serve }; Status: success: OK. Took 588881 microseconds.
+2026-04-29 15:17:41.476687: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
+2026-04-29 15:17:41.497650: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
+2026.04.29-15:17:41.45 - <debug> Initializing vAccel
+2026.04.29-15:17:41.45 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-15:17:41.45 - <debug> Config:
+2026.04.29-15:17:41.45 - <debug>   plugins = libvaccel-tf.so
+2026.04.29-15:17:41.45 - <debug>   log_level = debug
+2026.04.29-15:17:41.45 - <debug>   log_file = (null)
+2026.04.29-15:17:41.45 - <debug>   profiling_enabled = false
+2026.04.29-15:17:41.45 - <debug>   version_ignore = false
+2026.04.29-15:17:41.45 - <debug> Created top-level rundir: /run/user/0/vaccel/LcX7hW
+2026.04.29-15:17:41.50 - <info> Registered plugin tf 0.2.0-22-b9061d01
+2026.04.29-15:17:41.50 - <debug> Registered op tf_model_load from plugin tf
+2026.04.29-15:17:41.50 - <debug> Registered op tf_model_unload from plugin tf
+2026.04.29-15:17:41.50 - <debug> Registered op tf_model_run from plugin tf
+2026.04.29-15:17:41.50 - <debug> Registered op tflite_model_load from plugin tf
+2026.04.29-15:17:41.50 - <debug> Registered op tflite_model_unload from plugin tf
+2026.04.29-15:17:41.50 - <debug> Registered op tflite_model_run from plugin tf
+2026.04.29-15:17:41.50 - <debug> Loaded plugin tf from libvaccel-tf.so
+2026.04.29-15:17:41.50 - <debug> New rundir for session 1: /run/user/0/vaccel/LcX7hW/session.1
+2026.04.29-15:17:41.50 - <debug> Initialized session 1 with plugin tf
+2026.04.29-15:17:41.50 - <warn> Path does not seem to have a `<prefix>://`
+2026.04.29-15:17:41.50 - <warn> Assuming lstm2/ is a local path
+2026.04.29-15:17:41.50 - <debug> Initialized resource 1
+2026.04.29-15:17:41.50 - <debug> session:1 Registered resource 1
+2026.04.29-15:17:41.50 - <debug> session:1 Looking for func implementing op tf_model_load
+2026.04.29-15:17:41.50 - <debug> Returning func for op tf_model_load from plugin tf
+2026.04.29-15:17:41.50 - <debug> [tf] Loading session from SavedModel
+2026-04-29 15:17:41.509281: I tensorflow/cc/saved_model/reader.cc:83] Reading SavedModel from: lstm2/
+2026-04-29 15:17:41.528615: I tensorflow/cc/saved_model/reader.cc:52] Reading meta graph with tags { serve }
+2026-04-29 15:17:41.528668: I tensorflow/cc/saved_model/reader.cc:147] Reading SavedModel debug info (if present) from: lstm2/
+2026-04-29 15:17:41.528730: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
+To enable the following instructions: SSE3 SSE4.1 SSE4.2 AVX AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
+2026-04-29 15:17:41.620620: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:388] MLIR V1 optimization pass is not enabled
+2026-04-29 15:17:41.646083: I tensorflow/cc/saved_model/loader.cc:236] Restoring SavedModel bundle.
+2026-04-29 15:17:41.732098: I tensorflow/cc/saved_model/loader.cc:220] Running initialization op on SavedModel bundle at path: lstm2/
+2026-04-29 15:17:41.815607: I tensorflow/cc/saved_model/loader.cc:462] SavedModel load for tags { serve }; Status: success: OK. Took 306330 microseconds.
+2026.04.29-15:17:41.87 - <debug> [tf] Model loaded correctly
+2026-04-29 15:17:41.873345: I tensorflow/cc/saved_model/reader.cc:83] Reading SavedModel from: lstm2/
+2026-04-29 15:17:41.893528: I tensorflow/cc/saved_model/reader.cc:52] Reading meta graph with tags { serve }
+2026-04-29 15:17:41.893586: I tensorflow/cc/saved_model/reader.cc:147] Reading SavedModel debug info (if present) from: lstm2/
+2026-04-29 15:17:41.997364: I tensorflow/cc/saved_model/loader.cc:236] Restoring SavedModel bundle.
+2026-04-29 15:17:42.075262: I tensorflow/cc/saved_model/loader.cc:220] Running initialization op on SavedModel bundle at path: lstm2/
+2026-04-29 15:17:42.156119: I tensorflow/cc/saved_model/loader.cc:462] SavedModel load for tags { serve }; Status: success: OK. Took 282782 microseconds.
 TF_LoadSessionFromSavedModel OK
 TF_GraphOperationByName serving_default_input_1 is OK
 TF_GraphOperationByName StatefulPartitionedCall is OK
 TF_NewTensor is OK
-2025.03.25-22:27:31.81 - <debug> session:1 Looking for plugin implementing tf_session_run operation
-2025.03.25-22:27:31.81 - <debug> Returning func from hint plugin tf
-2025.03.25-22:27:31.81 - <debug> Found implementation in tf plugin
-2025.03.25-22:27:31.81 - <debug> [tf] Running session
-2025.03.25-22:27:32.49 - <debug> [tf] Success
+2026.04.29-15:17:42.17 - <debug> session:1 Looking for func implementing op tf_model_run
+2026.04.29-15:17:42.17 - <debug> Returning func for op tf_model_run from plugin tf
+2026.04.29-15:17:42.17 - <debug> [tf] Running session
+2026.04.29-15:17:42.58 - <debug> [tf] Success
 Session is OK
-2025.03.25-22:27:32.49 - <debug> session:1 Looking for plugin implementing tf_session_delete operation
-2025.03.25-22:27:32.49 - <debug> Returning func from hint plugin tf
-2025.03.25-22:27:32.49 - <debug> Found implementation in tf plugin
-2025.03.25-22:27:32.49 - <debug> [tf] Deleting session
-2025.03.25-22:27:32.59 - <debug> session:1 Unregistered resource 1
-2025.03.25-22:27:32.59 - <debug> Released resource 1
-2025.03.25-22:27:32.69 - <debug> Released session 1
+2026.04.29-15:17:42.58 - <debug> session:1 Looking for func implementing op tf_model_unload
+2026.04.29-15:17:42.58 - <debug> Returning func for op tf_model_unload from plugin tf
+2026.04.29-15:17:42.58 - <debug> [tf] Deleting session
+2026.04.29-15:17:42.61 - <debug> session:1 Unregistered resource 1
+2026.04.29-15:17:42.61 - <debug> Released resource 1
+2026.04.29-15:17:42.64 - <debug> Released session 1
 Result Tensor :
 0.016328
 0.016542
@@ -150,9 +151,9 @@ Result Tensor :
 0.016437
 0.016353
 0.016246
-2025.03.25-22:27:32.69 - <debug> Cleaning up vAccel
-2025.03.25-22:27:32.69 - <debug> Cleaning up sessions
-2025.03.25-22:27:32.69 - <debug> Cleaning up resources
-2025.03.25-22:27:32.69 - <debug> Cleaning up plugins
-2025.03.25-22:27:32.69 - <debug> Unregistered plugin tf
+2026.04.29-15:17:42.64 - <debug> Cleaning up vAccel
+2026.04.29-15:17:42.64 - <debug> Cleaning up sessions
+2026.04.29-15:17:42.64 - <debug> Cleaning up resources
+2026.04.29-15:17:42.64 - <debug> Cleaning up plugins
+2026.04.29-15:17:42.64 - <debug> Unregistered plugin tf
 ```

--- a/docs/getting-started/introduction-to-plugins.md
+++ b/docs/getting-started/introduction-to-plugins.md
@@ -23,32 +23,27 @@ themselves (ie. undefined symbols) but the operation will fail at runtime:
 
 ```console
 $ classify /usr/local/share/vaccel/images/example.jpg 1
-2025.04.05-19:25:04.80 - <debug> Initializing vAccel
-2025.04.05-19:25:04.80 - <info> vAccel 0.6.1-194-19056528
-2025.04.05-19:25:04.80 - <debug> Config:
-2025.04.05-19:25:04.80 - <debug>   plugins = (null)
-2025.04.05-19:25:04.80 - <debug>   log_level = debug
-2025.04.05-19:25:04.80 - <debug>   log_file = (null)
-2025.04.05-19:25:04.80 - <debug>   profiling_enabled = false
-2025.04.05-19:25:04.80 - <debug>   version_ignore = false
-2025.04.05-19:25:04.80 - <debug> Created top-level rundir: /run/user/1002/vaccel/k0R150
-2025.04.05-19:25:04.80 - <debug> New rundir for session 1: /run/user/1002/vaccel/k0R150/session.1
-2025.04.05-19:25:04.80 - <debug> Initialized session 1
-Initialized session with id: 1
-2025.04.05-19:25:04.80 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.05-19:25:04.80 - <warn> None of the loaded plugins implement VACCEL_OP_IMAGE_CLASSIFY
-Could not run op: 95
-2025.04.05-19:25:04.80 - <debug> Released session 1
-2025.04.05-19:25:04.80 - <debug> Cleaning up vAccel
-2025.04.05-19:25:04.80 - <debug> Cleaning up sessions
-2025.04.05-19:25:04.80 - <debug> Cleaning up resources
-2025.04.05-19:25:04.80 - <debug> Cleaning up plugins
+2026.04.29-14:49:05.41 - <debug> Initializing vAccel
+2026.04.29-14:49:05.41 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-14:49:05.41 - <debug> Config:
+2026.04.29-14:49:05.41 - <debug>   plugins = (null)
+2026.04.29-14:49:05.41 - <debug>   log_level = debug
+2026.04.29-14:49:05.41 - <debug>   log_file = (null)
+2026.04.29-14:49:05.41 - <debug>   profiling_enabled = false
+2026.04.29-14:49:05.41 - <debug>   version_ignore = false
+2026.04.29-14:49:05.41 - <debug> Created top-level rundir: /run/user/0/vaccel/wrlzzl
+2026.04.29-14:49:05.41 - <error> No plugins registered
+Could not initialize session
+2026.04.29-14:49:05.41 - <debug> Cleaning up vAccel
+2026.04.29-14:49:05.41 - <debug> Cleaning up sessions
+2026.04.29-14:49:05.41 - <debug> Cleaning up resources
+2026.04.29-14:49:05.41 - <debug> Cleaning up plugins
 ```
 
-It is clear from the output that no implementation is found for the
-`VACCEL_OP_IMAGE_CLASSIFY` operation. By comparing the output with
+It is clear from the output that the session cannot be initialized because no
+plugin has been loaded. By comparing the output with
 [classify](running-the-examples.md#classify-noop-debug) from the previous
-document, you can see that the reason is that no plugin has been loaded.
+document, you can see that there are no registered plugins.
 
 You can find out more about the available plugins and their usage in the
 [Plugins](../plugins/index.md) section.

--- a/docs/getting-started/running-the-examples.md
+++ b/docs/getting-started/running-the-examples.md
@@ -44,62 +44,62 @@ The output will now be:
 
 ```console
 $ classify /usr/local/share/vaccel/images/example.jpg 1
-2025.04.03-15:44:04.61 - <debug> Initializing vAccel
-2025.04.03-15:44:04.61 - <info> vAccel 0.6.1-194-19056528
-2025.04.03-15:44:04.61 - <debug> Config:
-2025.04.03-15:44:04.61 - <debug>   plugins = libvaccel-noop.so
-2025.04.03-15:44:04.61 - <debug>   log_level = debug
-2025.04.03-15:44:04.61 - <debug>   log_file = (null)
-2025.04.03-15:44:04.61 - <debug>   profiling_enabled = false
-2025.04.03-15:44:04.61 - <debug>   version_ignore = false
-2025.04.03-15:44:04.61 - <debug> Created top-level rundir: /run/user/1002/vaccel/VC0Gxz
-2025.04.03-15:44:04.61 - <info> Registered plugin noop 0.6.1-194-19056528
-2025.04.03-15:44:04.61 - <debug> Registered op noop from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op blas_sgemm from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op image_classify from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op image_detect from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op image_segment from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op image_pose from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op image_depth from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op exec from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tf_session_load from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tf_session_run from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tf_session_delete from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op minmax from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op fpga_arraycopy from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op fpga_vectoradd from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op fpga_parallel from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op fpga_mmult from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op exec_with_resource from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op torch_jitload_forward from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op torch_sgemm from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op opencv from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tflite_session_load from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tflite_session_run from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tflite_session_delete from plugin noop
-2025.04.03-15:44:04.61 - <debug> Loaded plugin noop from libvaccel-noop.so
-2025.04.03-15:44:04.62 - <debug> New rundir for session 1: /run/user/1002/vaccel/VC0Gxz/session.1
-2025.04.03-15:44:04.62 - <debug> Initialized session 1
+2026.04.29-14:47:59.38 - <debug> Initializing vAccel
+2026.04.29-14:47:59.38 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-14:47:59.38 - <debug> Config:
+2026.04.29-14:47:59.38 - <debug>   plugins = libvaccel-noop.so
+2026.04.29-14:47:59.38 - <debug>   log_level = debug
+2026.04.29-14:47:59.38 - <debug>   log_file = (null)
+2026.04.29-14:47:59.38 - <debug>   profiling_enabled = false
+2026.04.29-14:47:59.38 - <debug>   version_ignore = false
+2026.04.29-14:47:59.38 - <debug> Created top-level rundir: /run/user/0/vaccel/fPAGh6
+2026.04.29-14:47:59.38 - <info> Registered plugin noop 0.7.1-93-ebc23b1f
+2026.04.29-14:47:59.38 - <debug> Registered op noop from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op exec from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op exec_with_resource from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op image_classify from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op image_detect from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op image_segment from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op image_pose from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op image_depth from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op tf_model_load from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op tf_model_unload from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op tf_model_run from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op tflite_model_load from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op tflite_model_unload from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op tflite_model_run from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op torch_model_load from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op torch_model_run from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op torch_sgemm from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op blas_sgemm from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op fpga_arraycopy from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op fpga_vectoradd from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op fpga_parallel from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op fpga_mmult from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op minmax from plugin noop
+2026.04.29-14:47:59.38 - <debug> Registered op opencv from plugin noop
+2026.04.29-14:47:59.38 - <debug> Loaded plugin noop from libvaccel-noop.so
+2026.04.29-14:47:59.38 - <debug> New rundir for session 1: /run/user/0/vaccel/fPAGh6/session.1
+2026.04.29-14:47:59.38 - <debug> Initialized session 1 with plugin noop
 Initialized session with id: 1
-2025.04.03-15:44:04.62 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.03-15:44:04.62 - <debug> Returning func from hint plugin noop
-2025.04.03-15:44:04.62 - <debug> Found implementation in noop plugin
-2025.04.03-15:44:04.62 - <debug> [noop] Calling Image classification for session 1
-2025.04.03-15:44:04.62 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.03-15:44:04.62 - <debug> [noop] model: (null)
-2025.04.03-15:44:04.62 - <debug> [noop] len_img: 79281
-2025.04.03-15:44:04.62 - <debug> [noop] len_out_text: 512
-2025.04.03-15:44:04.62 - <debug> [noop] len_out_imgname: 512
-2025.04.03-15:44:04.62 - <debug> [noop] will return a dummy result
-2025.04.03-15:44:04.62 - <debug> [noop] will return a dummy result
+2026.04.29-14:47:59.38 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.29-14:47:59.38 - <debug> Returning func for op image_classify from plugin noop
+2026.04.29-14:47:59.38 - <debug> [noop] Calling Image classification for session 1
+2026.04.29-14:47:59.38 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.29-14:47:59.38 - <debug> [noop] model: (null)
+2026.04.29-14:47:59.38 - <debug> [noop] len_img: 79281
+2026.04.29-14:47:59.38 - <debug> [noop] len_out_text: 512
+2026.04.29-14:47:59.38 - <debug> [noop] len_out_imgname: 512
+2026.04.29-14:47:59.38 - <debug> [noop] will return a dummy result
+2026.04.29-14:47:59.38 - <debug> [noop] will return a dummy result
 classification tags: This is a dummy classification tag!
 classification imagename: This is a dummy imgname!
-2025.04.03-15:44:04.62 - <debug> Released session 1
-2025.04.03-15:44:04.62 - <debug> Cleaning up vAccel
-2025.04.03-15:44:04.62 - <debug> Cleaning up sessions
-2025.04.03-15:44:04.62 - <debug> Cleaning up resources
-2025.04.03-15:44:04.62 - <debug> Cleaning up plugins
-2025.04.03-15:44:04.62 - <debug> Unregistered plugin noop
+2026.04.29-14:47:59.38 - <debug> Released session 1
+2026.04.29-14:47:59.38 - <debug> Cleaning up vAccel
+2026.04.29-14:47:59.38 - <debug> Cleaning up sessions
+2026.04.29-14:47:59.38 - <debug> Cleaning up resources
+2026.04.29-14:47:59.38 - <debug> Cleaning up plugins
+2026.04.29-14:47:59.38 - <debug> Unregistered plugin noop
 ```
 
 You can find sample invocation commands for all the examples in the

--- a/docs/language-bindings/go-bindings/usage.md
+++ b/docs/language-bindings/go-bindings/usage.md
@@ -64,67 +64,66 @@ output:
 ```console
 $ go run github.com/nubificus/vaccel-go/examples/classify \
       /usr/local/share/vaccel/images/example.jpg
-2025.04.15-16:51:03.74 - <debug> Initializing vAccel
-2025.04.15-16:51:03.74 - <info> vAccel 0.6.1-194-19056528
-2025.04.15-16:51:03.74 - <debug> Config:
-2025.04.15-16:51:03.74 - <debug>   plugins = libvaccel-noop.so
-2025.04.15-16:51:03.74 - <debug>   log_level = debug
-2025.04.15-16:51:03.74 - <debug>   log_file = (null)
-2025.04.15-16:51:03.74 - <debug>   profiling_enabled = false
-2025.04.15-16:51:03.74 - <debug>   version_ignore = false
-2025.04.15-16:51:03.74 - <debug> Created top-level rundir: /run/user/1002/vaccel/37513G
-2025.04.15-16:51:03.75 - <info> Registered plugin noop 0.6.1-194-19056528
-2025.04.15-16:51:03.75 - <debug> Registered op noop from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op blas_sgemm from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op image_classify from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op image_detect from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op image_segment from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op image_pose from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op image_depth from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op exec from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op tf_session_load from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op tf_session_run from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op tf_session_delete from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op minmax from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op fpga_arraycopy from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op fpga_vectoradd from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op fpga_parallel from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op fpga_mmult from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op exec_with_resource from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op torch_jitload_forward from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op torch_sgemm from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op opencv from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op tflite_session_load from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op tflite_session_run from plugin noop
-2025.04.15-16:51:03.75 - <debug> Registered op tflite_session_delete from plugin noop
-2025.04.15-16:51:03.75 - <debug> Loaded plugin noop from libvaccel-noop.so
-2025.04.15-16:51:03.75 - <debug> New rundir for session 1: /run/user/1002/vaccel/37513G/session.1
-2025.04.15-16:51:03.75 - <debug> Initialized session 1
-2025.04.15-16:51:03.75 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.15-16:51:03.75 - <debug> Returning func from hint plugin noop
-2025.04.15-16:51:03.75 - <debug> Found implementation in noop plugin
-2025.04.15-16:51:03.75 - <debug> [noop] Calling Image classification for session 1
-2025.04.15-16:51:03.75 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.15-16:51:03.75 - <debug> [noop] model: (null)
-2025.04.15-16:51:03.75 - <debug> [noop] len_img: 79281
-2025.04.15-16:51:03.75 - <debug> [noop] len_out_text: 256
-2025.04.15-16:51:03.75 - <debug> [noop] len_out_imgname: 256
-2025.04.15-16:51:03.75 - <debug> [noop] will return a dummy result
-2025.04.15-16:51:03.75 - <debug> [noop] will return a dummy result
+2026.04.29-15:00:35.94 - <debug> Initializing vAccel
+2026.04.29-15:00:35.94 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-15:00:35.94 - <debug> Config:
+2026.04.29-15:00:35.94 - <debug>   plugins = libvaccel-noop.so
+2026.04.29-15:00:35.94 - <debug>   log_level = debug
+2026.04.29-15:00:35.94 - <debug>   log_file = (null)
+2026.04.29-15:00:35.94 - <debug>   profiling_enabled = false
+2026.04.29-15:00:35.94 - <debug>   version_ignore = false
+2026.04.29-15:00:35.94 - <debug> Created top-level rundir: /run/user/0/vaccel/co8ekx
+2026.04.29-15:00:35.94 - <info> Registered plugin noop 0.7.1-93-ebc23b1f
+2026.04.29-15:00:35.94 - <debug> Registered op noop from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op exec from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op exec_with_resource from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op image_classify from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op image_detect from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op image_segment from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op image_pose from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op image_depth from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op tf_model_load from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op tf_model_unload from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op tf_model_run from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op tflite_model_load from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op tflite_model_unload from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op tflite_model_run from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op torch_model_load from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op torch_model_run from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op torch_sgemm from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op blas_sgemm from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op fpga_arraycopy from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op fpga_vectoradd from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op fpga_parallel from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op fpga_mmult from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op minmax from plugin noop
+2026.04.29-15:00:35.94 - <debug> Registered op opencv from plugin noop
+2026.04.29-15:00:35.94 - <debug> Loaded plugin noop from libvaccel-noop.so
+2026.04.29-15:00:35.94 - <debug> New rundir for session 1: /run/user/0/vaccel/co8ekx/session.1
+2026.04.29-15:00:35.94 - <debug> Initialized session 1 with plugin noop
+2026.04.29-15:00:35.94 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.29-15:00:35.94 - <debug> Returning func for op image_classify from plugin noop
+2026.04.29-15:00:35.94 - <debug> [noop] Calling Image classification for session 1
+2026.04.29-15:00:35.94 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.29-15:00:35.94 - <debug> [noop] model: (null)
+2026.04.29-15:00:35.94 - <debug> [noop] len_img: 79281
+2026.04.29-15:00:35.94 - <debug> [noop] len_out_text: 256
+2026.04.29-15:00:35.94 - <debug> [noop] len_out_imgname: 256
+2026.04.29-15:00:35.94 - <debug> [noop] will return a dummy result
+2026.04.29-15:00:35.94 - <debug> [noop] will return a dummy result
 Output(1):  This is a dummy classification tag!
-2025.04.15-16:51:03.75 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.15-16:51:03.75 - <debug> Returning func from hint plugin noop
-2025.04.15-16:51:03.75 - <debug> Found implementation in noop plugin
-2025.04.15-16:51:03.75 - <debug> [noop] Calling Image classification for session 1
-2025.04.15-16:51:03.75 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.15-16:51:03.75 - <debug> [noop] model: (null)
-2025.04.15-16:51:03.75 - <debug> [noop] len_img: 79281
-2025.04.15-16:51:03.75 - <debug> [noop] len_out_text: 256
-2025.04.15-16:51:03.75 - <debug> [noop] len_out_imgname: 256
-2025.04.15-16:51:03.75 - <debug> [noop] will return a dummy result
-2025.04.15-16:51:03.75 - <debug> [noop] will return a dummy result
+2026.04.29-15:00:35.94 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.29-15:00:35.94 - <debug> Returning func for op image_classify from plugin noop
+2026.04.29-15:00:35.94 - <debug> [noop] Calling Image classification for session 1
+2026.04.29-15:00:35.94 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.29-15:00:35.94 - <debug> [noop] model: (null)
+2026.04.29-15:00:35.94 - <debug> [noop] len_img: 79281
+2026.04.29-15:00:35.94 - <debug> [noop] len_out_text: 256
+2026.04.29-15:00:35.94 - <debug> [noop] len_out_imgname: 256
+2026.04.29-15:00:35.94 - <debug> [noop] will return a dummy result
+2026.04.29-15:00:35.94 - <debug> [noop] will return a dummy result
 Output(2):  This is a dummy classification tag!
-2025.04.15-16:51:03.75 - <debug> Released session 1
+2026.04.29-15:00:35.94 - <debug> Released session 1
 ```
 
 ## Installing the examples

--- a/docs/language-bindings/python-bindings/writing-a-simple-vaccel-python-application.md
+++ b/docs/language-bindings/python-bindings/writing-a-simple-vaccel-python-application.md
@@ -55,61 +55,61 @@ you can get the verbose version of the output:
 
 ```console
 $ python3 classify.py /usr/local/share/vaccel/images/example.jpg
-2025.04.13-21:21:39.87 - <debug> Initializing vAccel
-2025.04.13-21:21:39.87 - <info> vAccel 0.6.1-194-19056528
-2025.04.13-21:21:39.87 - <debug> Config:
-2025.04.13-21:21:39.87 - <debug>   plugins = libvaccel-noop.so
-2025.04.13-21:21:39.87 - <debug>   log_level = debug
-2025.04.13-21:21:39.87 - <debug>   log_file = (null)
-2025.04.13-21:21:39.87 - <debug>   profiling_enabled = false
-2025.04.13-21:21:39.87 - <debug>   version_ignore = false
-2025.04.13-21:21:39.87 - <debug> Created top-level rundir: /run/user/1002/vaccel/WTLhQW
-2025.04.13-21:21:39.87 - <info> Registered plugin noop 0.6.1-194-19056528
-2025.04.13-21:21:39.87 - <debug> Registered op noop from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op blas_sgemm from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op image_classify from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op image_detect from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op image_segment from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op image_pose from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op image_depth from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op exec from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op tf_session_load from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op tf_session_run from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op tf_session_delete from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op minmax from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op fpga_arraycopy from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op fpga_vectoradd from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op fpga_parallel from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op fpga_mmult from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op exec_with_resource from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op torch_jitload_forward from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op torch_sgemm from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op opencv from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op tflite_session_load from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op tflite_session_run from plugin noop
-2025.04.13-21:21:39.87 - <debug> Registered op tflite_session_delete from plugin noop
-2025.04.13-21:21:39.87 - <debug> Loaded plugin noop from libvaccel-noop.so
-2025.04.13-21:21:39.88 - <debug> New rundir for session 1: /run/user/1002/vaccel/WTLhQW/session.1
-2025.04.13-21:21:39.88 - <debug> Initialized session 1
+2026.04.29-15:07:13.91 - <debug> Initializing vAccel
+2026.04.29-15:07:13.91 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-15:07:13.91 - <debug> Config:
+2026.04.29-15:07:13.91 - <debug>   plugins = libvaccel-noop.so
+2026.04.29-15:07:13.91 - <debug>   log_level = debug
+2026.04.29-15:07:13.91 - <debug>   log_file = (null)
+2026.04.29-15:07:13.91 - <debug>   profiling_enabled = false
+2026.04.29-15:07:13.91 - <debug>   version_ignore = false
+2026.04.29-15:07:13.91 - <debug> Created top-level rundir: /run/user/0/vaccel/SlmFzq
+2026.04.29-15:07:13.91 - <info> Registered plugin noop 0.7.1-93-ebc23b1f
+2026.04.29-15:07:13.91 - <debug> Registered op noop from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op exec from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op exec_with_resource from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op image_classify from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op image_detect from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op image_segment from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op image_pose from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op image_depth from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op tf_model_load from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op tf_model_unload from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op tf_model_run from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op tflite_model_load from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op tflite_model_unload from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op tflite_model_run from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op torch_model_load from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op torch_model_run from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op torch_sgemm from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op blas_sgemm from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op fpga_arraycopy from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op fpga_vectoradd from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op fpga_parallel from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op fpga_mmult from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op minmax from plugin noop
+2026.04.29-15:07:13.91 - <debug> Registered op opencv from plugin noop
+2026.04.29-15:07:13.91 - <debug> Loaded plugin noop from libvaccel-noop.so
+2026.04.29-15:07:13.91 - <debug> New rundir for session 1: /run/user/0/vaccel/SlmFzq/session.1
+2026.04.29-15:07:13.91 - <debug> Initialized session 1 with plugin noop
+2026.04.29-15:07:13.91 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.29-15:07:13.91 - <debug> Returning func for op image_classify from plugin noop
+2026.04.29-15:07:13.91 - <debug> [noop] Calling Image classification for session 1
+2026.04.29-15:07:13.91 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.29-15:07:13.91 - <debug> [noop] model: (null)
+2026.04.29-15:07:13.91 - <debug> [noop] len_img: 79281
+2026.04.29-15:07:13.91 - <debug> [noop] len_out_text: 512
+2026.04.29-15:07:13.91 - <debug> [noop] len_out_imgname: 512
+2026.04.29-15:07:13.91 - <debug> [noop] will return a dummy result
+2026.04.29-15:07:13.91 - <debug> [noop] will return a dummy result
+2026.04.29-15:07:13.91 - <debug> Released session 1
 Session id is 1
-2025.04.13-21:21:39.88 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.13-21:21:39.88 - <debug> Returning func from hint plugin noop
-2025.04.13-21:21:39.88 - <debug> Found implementation in noop plugin
-2025.04.13-21:21:39.88 - <debug> [noop] Calling Image classification for session 1
-2025.04.13-21:21:39.88 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.13-21:21:39.88 - <debug> [noop] model: (null)
-2025.04.13-21:21:39.88 - <debug> [noop] len_img: 79281
-2025.04.13-21:21:39.88 - <debug> [noop] len_out_text: 500
-2025.04.13-21:21:39.88 - <debug> [noop] len_out_imgname: 500
-2025.04.13-21:21:39.88 - <debug> [noop] will return a dummy result
-2025.04.13-21:21:39.88 - <debug> [noop] will return a dummy result
 ('This is a dummy classification tag!', 'This is a dummy imgname!')
-2025.04.13-21:21:39.88 - <debug> Released session 1
-2025.04.13-21:21:39.89 - <debug> Cleaning up vAccel
-2025.04.13-21:21:39.89 - <debug> Cleaning up sessions
-2025.04.13-21:21:39.89 - <debug> Cleaning up resources
-2025.04.13-21:21:39.89 - <debug> Cleaning up plugins
-2025.04.13-21:21:39.89 - <debug> Unregistered plugin noop
+2026.04.29-15:07:13.91 - <debug> Cleaning up vAccel
+2026.04.29-15:07:13.91 - <debug> Cleaning up sessions
+2026.04.29-15:07:13.91 - <debug> Cleaning up resources
+2026.04.29-15:07:13.91 - <debug> Cleaning up plugins
+2026.04.29-15:07:13.91 - <debug> Unregistered plugin noop
 ```
 
 The vAccel output of

--- a/docs/language-bindings/rust-bindings/usage.md
+++ b/docs/language-bindings/rust-bindings/usage.md
@@ -63,20 +63,15 @@ note: to keep the current resolver, specify `workspace.resolver = "1"` in the wo
 note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
 note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
     Updating crates.io index
-    Updating git repository `https://github.com/nubificus/ttrpc-rust.git`
-   Compiling proc-macro2 v1.0.95
-   Compiling unicode-ident v1.0.18
+   Compiling proc-macro2 v1.0.106
+   Compiling unicode-ident v1.0.24
 [snipped]
-   Compiling vaccel v0.0.0 (/home/ananos/develop/fresh/playground/vaccel-rust/vaccel-bindings)
-   Compiling futures-executor v0.3.31
-   Compiling futures v0.3.31
-   Compiling protobuf-parse v3.7.2
-   Compiling tokio-vsock v0.4.0
-   Compiling protobuf-codegen v3.7.2
-   Compiling ttrpc-codegen v0.5.0 (https://github.com/nubificus/ttrpc-rust.git?branch=vaccel-dev#30b79e78)
-   Compiling ttrpc v0.8.3 (https://github.com/nubificus/ttrpc-rust.git?branch=vaccel-dev#30b79e78)
-   Compiling vaccel-rpc-proto v0.0.0 (/home/ananos/develop/fresh/playground/vaccel-rust/vaccel-rpc-proto)
-    Finished dev [unoptimized + debuginfo] target(s) in 24.59s
+   Compiling protobuf v3.7.2
+   Compiling protobuf-support v3.7.2
+   Compiling vaccel v0.0.0 (/tmp/vaccel-rust/vaccel-bindings)
+   Compiling dashmap v6.1.0
+   Compiling env_logger v0.11.10
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.92s
 ```
 
 If all went well, the examples' binaries should be available in
@@ -100,11 +95,9 @@ and, assuming vAccel is installed at `/usr/local`, run with:
 
 ```console
 $ ../target/debug/examples/session
-[2025-04-16T14:44:07Z INFO  session] Starting vAccel session handling example
-[2025-04-16T14:44:07Z INFO  session] Creating new vAccel session
-[2025-04-16T14:44:07Z INFO  session] Initialized session 1
-[2025-04-16T14:44:07Z INFO  session] Releasing session 1
-[2025-04-16T14:44:07Z INFO  session] Done
+[2026-04-29T14:51:35Z INFO  session] Starting vAccel session handling example
+[2026-04-29T14:51:35Z INFO  session] Creating new vAccel session
+[2026-04-29T14:51:35Z INFO  session] Initialized session 1
 ```
 
 By setting log level to debug:
@@ -117,51 +110,50 @@ you can see the verbose vAccel output:
 
 ```console
 $ ../target/debug/examples/session
-2025.04.16-14:43:15.99 - <debug> Initializing vAccel
-2025.04.16-14:43:15.99 - <info> vAccel 0.6.1-194-19056528
-2025.04.16-14:43:15.99 - <debug> Config:
-2025.04.16-14:43:15.99 - <debug>   plugins = libvaccel-noop.so
-2025.04.16-14:43:15.99 - <debug>   log_level = debug
-2025.04.16-14:43:15.99 - <debug>   log_file = (null)
-2025.04.16-14:43:15.99 - <debug>   profiling_enabled = true
-2025.04.16-14:43:15.99 - <debug>   version_ignore = true
-2025.04.16-14:43:15.99 - <debug> Created top-level rundir: /run/user/1000/vaccel/oOGHc5
-2025.04.16-14:43:15.99 - <info> Registered plugin noop 0.6.1-194-19056528
-2025.04.16-14:43:15.99 - <debug> Registered op noop from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op blas_sgemm from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op image_classify from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op image_detect from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op image_segment from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op image_pose from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op image_depth from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op exec from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op tf_session_load from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op tf_session_run from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op tf_session_delete from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op minmax from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op fpga_arraycopy from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op fpga_vectoradd from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op fpga_parallel from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op fpga_mmult from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op exec_with_resource from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op torch_jitload_forward from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op torch_sgemm from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op opencv from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op tflite_session_load from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op tflite_session_run from plugin noop
-2025.04.16-14:43:15.99 - <debug> Registered op tflite_session_delete from plugin noop
-2025.04.16-14:43:15.99 - <debug> Loaded plugin noop from libvaccel-noop.so
-[2025-04-16T14:43:15Z INFO  session] Starting vAccel session handling example
-[2025-04-16T14:43:15Z INFO  session] Creating new vAccel session
-2025.04.16-14:43:15.99 - <debug> New rundir for session 1: /run/user/1000/vaccel/oOGHc5/session.1
-2025.04.16-14:43:15.99 - <debug> Initialized session 1
-[2025-04-16T14:43:15Z INFO  session] Initialized session 1
-[2025-04-16T14:43:15Z INFO  session] Releasing session 1
-2025.04.16-14:43:15.99 - <debug> Released session 1
-[2025-04-16T14:43:15Z INFO  session] Done
-2025.04.16-14:43:15.99 - <debug> Cleaning up vAccel
-2025.04.16-14:43:15.99 - <debug> Cleaning up sessions
-2025.04.16-14:43:15.99 - <debug> Cleaning up resources
-2025.04.16-14:43:15.99 - <debug> Cleaning up plugins
-2025.04.16-14:43:15.99 - <debug> Unregistered plugin noop
+[2026-04-29T14:51:35Z INFO  session] Starting vAccel session handling example
+[2026-04-29T14:51:35Z INFO  session] Creating new vAccel session
+2026.04.29-14:51:35.50 - <debug> Initializing vAccel
+2026.04.29-14:51:35.50 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-14:51:35.50 - <debug> Config:
+2026.04.29-14:51:35.50 - <debug>   plugins = libvaccel-noop.so
+2026.04.29-14:51:35.50 - <debug>   log_level = debug
+2026.04.29-14:51:35.50 - <debug>   log_file = (null)
+2026.04.29-14:51:35.50 - <debug>   profiling_enabled = false
+2026.04.29-14:51:35.50 - <debug>   version_ignore = false
+2026.04.29-14:51:35.50 - <debug> Created top-level rundir: /run/user/0/vaccel/qAtMaP
+2026.04.29-14:51:35.50 - <info> Registered plugin noop 0.7.1-93-ebc23b1f
+2026.04.29-14:51:35.50 - <debug> Registered op noop from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op exec from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op exec_with_resource from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op image_classify from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op image_detect from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op image_segment from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op image_pose from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op image_depth from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op tf_model_load from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op tf_model_unload from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op tf_model_run from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op tflite_model_load from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op tflite_model_unload from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op tflite_model_run from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op torch_model_load from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op torch_model_run from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op torch_sgemm from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op blas_sgemm from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op fpga_arraycopy from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op fpga_vectoradd from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op fpga_parallel from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op fpga_mmult from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op minmax from plugin noop
+2026.04.29-14:51:35.50 - <debug> Registered op opencv from plugin noop
+2026.04.29-14:51:35.50 - <debug> Loaded plugin noop from libvaccel-noop.so
+2026.04.29-14:51:35.50 - <debug> New rundir for session 1: /run/user/0/vaccel/qAtMaP/session.1
+2026.04.29-14:51:35.50 - <debug> Initialized session 1 with plugin noop
+[2026-04-29T14:51:35Z INFO  session] Initialized session 1
+2026.04.29-14:51:35.50 - <debug> Released session 1
+2026.04.29-14:51:35.50 - <debug> Cleaning up vAccel
+2026.04.29-14:51:35.50 - <debug> Cleaning up sessions
+2026.04.29-14:51:35.50 - <debug> Cleaning up resources
+2026.04.29-14:51:35.50 - <debug> Cleaning up plugins
+2026.04.29-14:51:35.50 - <debug> Unregistered plugin noop
 ```

--- a/docs/language-bindings/rust-bindings/writing-a-simple-vaccel-rust-application.md
+++ b/docs/language-bindings/rust-bindings/writing-a-simple-vaccel-rust-application.md
@@ -64,7 +64,7 @@ use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use vaccel::*;
+use vaccel::session::Session;
 
 fn main() {
     env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
@@ -83,14 +83,14 @@ fn main() {
     }
 
     info!("Creating new vAccel session");
-    let mut sess = match Session::new(0) {
+    let mut sess = match Session::new() {
         Ok(sess) => sess,
         Err(e) => {
             error!("Error creating session: {}", e);
             return;
         }
     };
-    info!("Initialized session {}", sess.id());
+    info!("Initialized session {}", sess.id().unwrap());
 
     info!("Reading image file: {}", image_path);
     let mut file = match File::open(image_path) {
@@ -109,7 +109,7 @@ fn main() {
     info!("Read image data: {} bytes", image_data.len());
 
     info!("Performing image classification");
-    let ret = sess.image_classification(&mut image_data);
+    let ret = sess.image_classification(&image_data);
 
     match ret {
         Ok((first_vec, second_vec)) => {
@@ -124,23 +124,11 @@ fn main() {
             error!("Classification failed: {:?}", e);
         }
     }
-
-    info!("Releasing session {}", sess.id());
-    match sess.release() {
-        Ok(()) => info!("Session released successfully"),
-        Err(e) => error!("Error releasing session: {}", e),
-    }
 }
 ```
 
-<!-- markdownlint-disable code-block-style -->
-
-!!! note
-
-    You can omit `sess.release()` if you don't need custom error handling. The
-    session will be released when the object is dropped.
-
-<!-- markdownlint-restore -->
+The session is released automatically when `sess` is dropped at the end of
+`main()`.
 
 Build it:
 
@@ -148,21 +136,18 @@ Build it:
 $ cargo build
     Updating crates.io index
     Updating git repository `https://github.com/nubificus/vaccel-rust`
-    Updating git repository `https://github.com/nubificus/ttrpc-rust.git`
-   Compiling proc-macro2 v1.0.95
-   Compiling unicode-ident v1.0.18
+   Compiling proc-macro2 v1.0.106
+   Compiling unicode-ident v1.0.24
    Compiling autocfg v1.4.0
    Compiling cfg-if v1.0.0
 [snipped]
-   Compiling tokio-vsock v0.4.0
-   Compiling vaccel v0.0.0 (https://github.com/nubificus/vaccel-rust#0af1c664)
-   Compiling protobuf-parse v3.7.2
-   Compiling protobuf-codegen v3.7.2
-   Compiling ttrpc-codegen v0.5.0 (https://github.com/nubificus/ttrpc-rust.git?branch=vaccel-dev#30b79e78)
-   Compiling ttrpc v0.8.3 (https://github.com/nubificus/ttrpc-rust.git?branch=vaccel-dev#30b79e78)
-   Compiling vaccel-rpc-proto v0.0.0 (https://github.com/nubificus/vaccel-rust#0af1c664)
-   Compiling rust-vaccel-classify v0.1.0 (/home/ananos/develop/fresh/playground/rust-vaccel-classify)
-    Finished dev [unoptimized + debuginfo] target(s) in 25.90s
+   Compiling protobuf v3.7.2
+   Compiling protobuf-support v3.7.2
+   Compiling vaccel v0.0.0 (https://github.com/nubificus/vaccel-rust)
+   Compiling dashmap v6.1.0
+   Compiling env_logger v0.11.10
+   Compiling rust-vaccel-classify v0.1.0 (/tmp/rust-vaccel-classify)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 25.90s
 ```
 
 And you are ready to run your application.
@@ -177,75 +162,71 @@ export VACCEL_LOG_LEVEL=4
 and run with:
 
 ```console
-$ cargo run /usr/share/vaccel/images/example.jpg
-    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
-     Running `target/debug/rust-vaccel-classify /usr/share/vaccel/images/example.jpg`
-2025.04.16-14:39:45.13 - <debug> Initializing vAccel
-2025.04.16-14:39:45.13 - <info> vAccel 0.6.1-194-19056528
-2025.04.16-14:39:45.13 - <debug> Config:
-2025.04.16-14:39:45.13 - <debug>   plugins = libvaccel-noop.so
-2025.04.16-14:39:45.13 - <debug>   log_level = debug
-2025.04.16-14:39:45.13 - <debug>   log_file = (null)
-2025.04.16-14:39:45.13 - <debug>   profiling_enabled = true
-2025.04.16-14:39:45.13 - <debug>   version_ignore = true
-2025.04.16-14:39:45.13 - <debug> Created top-level rundir: /run/user/1000/vaccel/jesuwX
-2025.04.16-14:39:45.13 - <info> Registered plugin noop 0.6.1-194-19056528
-2025.04.16-14:39:45.13 - <debug> Registered op noop from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op blas_sgemm from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op image_classify from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op image_detect from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op image_segment from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op image_pose from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op image_depth from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op exec from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op tf_session_load from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op tf_session_run from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op tf_session_delete from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op minmax from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op fpga_arraycopy from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op fpga_vectoradd from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op fpga_parallel from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op fpga_mmult from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op exec_with_resource from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op torch_jitload_forward from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op torch_sgemm from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op opencv from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op tflite_session_load from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op tflite_session_run from plugin noop
-2025.04.16-14:39:45.13 - <debug> Registered op tflite_session_delete from plugin noop
-2025.04.16-14:39:45.13 - <debug> Loaded plugin noop from libvaccel-noop.so
-[2025-04-16T14:39:45Z INFO  rust_vaccel_classify] Starting vAccel classification example
-[2025-04-16T14:39:45Z INFO  rust_vaccel_classify] Creating new vAccel session
-2025.04.16-14:39:45.13 - <debug> New rundir for session 1: /run/user/1000/vaccel/jesuwX/session.1
-2025.04.16-14:39:45.13 - <debug> Initialized session 1
-[2025-04-16T14:39:45Z INFO  rust_vaccel_classify] Initialized session 1
-[2025-04-16T14:39:45Z INFO  rust_vaccel_classify] Reading image file: /usr/share/vaccel/images/example.jpg
-[2025-04-16T14:39:45Z INFO  rust_vaccel_classify] Read image data: 79281 bytes
-[2025-04-16T14:39:45Z INFO  rust_vaccel_classify] Performing image classification
-2025.04.16-14:39:45.13 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.16-14:39:45.13 - <debug> Start profiling region vaccel_image_op
-2025.04.16-14:39:45.13 - <debug> Returning func from hint plugin noop
-2025.04.16-14:39:45.13 - <debug> Found implementation in noop plugin
-2025.04.16-14:39:45.13 - <debug> [noop] Calling Image classification for session 1
-2025.04.16-14:39:45.13 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.16-14:39:45.13 - <debug> [noop] model: (null)
-2025.04.16-14:39:45.13 - <debug> [noop] len_img: 79281
-2025.04.16-14:39:45.13 - <debug> [noop] len_out_text: 1024
-2025.04.16-14:39:45.13 - <debug> [noop] len_out_imgname: 1024
-2025.04.16-14:39:45.13 - <debug> [noop] will return a dummy result
-2025.04.16-14:39:45.13 - <debug> [noop] will return a dummy result
-2025.04.16-14:39:45.13 - <debug> Stop profiling region vaccel_image_op
-[2025-04-16T14:39:45Z INFO  rust_vaccel_classify] Classification completed successfully
+$ cargo run /usr/local/share/vaccel/images/example.jpg
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
+     Running `target/debug/rust-vaccel-classify /usr/local/share/vaccel/images/example.jpg`
+[2026-04-29T14:57:01Z INFO  rust_vaccel_classify] Starting vAccel classification example
+[2026-04-29T14:57:01Z INFO  rust_vaccel_classify] Creating new vAccel session
+2026.04.29-14:57:01.16 - <debug> Initializing vAccel
+2026.04.29-14:57:01.16 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-14:57:01.16 - <debug> Config:
+2026.04.29-14:57:01.16 - <debug>   plugins = libvaccel-noop.so
+2026.04.29-14:57:01.16 - <debug>   log_level = debug
+2026.04.29-14:57:01.16 - <debug>   log_file = (null)
+2026.04.29-14:57:01.16 - <debug>   profiling_enabled = false
+2026.04.29-14:57:01.16 - <debug>   version_ignore = false
+2026.04.29-14:57:01.16 - <debug> Created top-level rundir: /run/user/0/vaccel/kZ5YUT
+2026.04.29-14:57:01.16 - <info> Registered plugin noop 0.7.1-93-ebc23b1f
+2026.04.29-14:57:01.16 - <debug> Registered op noop from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op exec from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op exec_with_resource from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op image_classify from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op image_detect from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op image_segment from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op image_pose from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op image_depth from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op tf_model_load from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op tf_model_unload from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op tf_model_run from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op tflite_model_load from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op tflite_model_unload from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op tflite_model_run from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op torch_model_load from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op torch_model_run from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op torch_sgemm from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op blas_sgemm from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op fpga_arraycopy from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op fpga_vectoradd from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op fpga_parallel from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op fpga_mmult from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op minmax from plugin noop
+2026.04.29-14:57:01.16 - <debug> Registered op opencv from plugin noop
+2026.04.29-14:57:01.16 - <debug> Loaded plugin noop from libvaccel-noop.so
+2026.04.29-14:57:01.16 - <debug> New rundir for session 1: /run/user/0/vaccel/kZ5YUT/session.1
+2026.04.29-14:57:01.16 - <debug> Initialized session 1 with plugin noop
+[2026-04-29T14:57:01Z INFO  rust_vaccel_classify] Initialized session 1
+[2026-04-29T14:57:01Z INFO  rust_vaccel_classify] Reading image file: /usr/local/share/vaccel/images/example.jpg
+[2026-04-29T14:57:01Z INFO  rust_vaccel_classify] Read image data: 79281 bytes
+[2026-04-29T14:57:01Z INFO  rust_vaccel_classify] Performing image classification
+2026.04.29-14:57:01.16 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.29-14:57:01.16 - <debug> Returning func for op image_classify from plugin noop
+2026.04.29-14:57:01.16 - <debug> [noop] Calling Image classification for session 1
+2026.04.29-14:57:01.16 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.29-14:57:01.16 - <debug> [noop] model: (null)
+2026.04.29-14:57:01.16 - <debug> [noop] len_img: 79281
+2026.04.29-14:57:01.16 - <debug> [noop] len_out_text: 1024
+2026.04.29-14:57:01.16 - <debug> [noop] len_out_imgname: 1024
+2026.04.29-14:57:01.16 - <debug> [noop] will return a dummy result
+2026.04.29-14:57:01.16 - <debug> [noop] will return a dummy result
+[2026-04-29T14:57:01Z INFO  rust_vaccel_classify] Classification completed successfully
 Classification tags: This is a dummy classification tag!
 Annotated image: This is a dummy imgname!
-[2025-04-16T14:39:45Z INFO  rust_vaccel_classify] Releasing session 1
-2025.04.16-14:39:45.13 - <debug> Released session 1
-[2025-04-16T14:39:45Z INFO  rust_vaccel_classify] Session released successfully
-2025.04.16-14:39:45.13 - <debug> Cleaning up vAccel
-2025.04.16-14:39:45.13 - <debug> Cleaning up sessions
-2025.04.16-14:39:45.13 - <debug> Cleaning up resources
-2025.04.16-14:39:45.13 - <debug> Cleaning up plugins
-2025.04.16-14:39:45.13 - <debug> Unregistered plugin noop
+2026.04.29-14:57:01.16 - <debug> Released session 1
+2026.04.29-14:57:01.16 - <debug> Cleaning up vAccel
+2026.04.29-14:57:01.16 - <debug> Cleaning up sessions
+2026.04.29-14:57:01.16 - <debug> Cleaning up resources
+2026.04.29-14:57:01.16 - <debug> Cleaning up plugins
+2026.04.29-14:57:01.16 - <debug> Unregistered plugin noop
 ```
 
 The vAccel output of

--- a/docs/plugins/available-plugins/acceleration-plugins/tf-plugin.md
+++ b/docs/plugins/available-plugins/acceleration-plugins/tf-plugin.md
@@ -118,87 +118,84 @@ $ tf_inference \
       /usr/local/share/vaccel/images/example.jpg \
       https://s3.nbfc.io/models/tf/resnet18-v2-7_saved_model.tar.xz \
       /usr/local/share/vaccel/labels/imagenet.txt
-2025.07.19-20:55:09.21 - <debug> Initializing vAccel
-2025.07.19-20:55:09.21 - <info> vAccel 0.7.1-22-edced930
-2025.07.19-20:55:09.21 - <debug> Config:
-2025.07.19-20:55:09.21 - <debug>   plugins = libvaccel-tf.so
-2025.07.19-20:55:09.21 - <debug>   log_level = debug
-2025.07.19-20:55:09.21 - <debug>   log_file = (null)
-2025.07.19-20:55:09.21 - <debug>   profiling_enabled = false
-2025.07.19-20:55:09.21 - <debug>   version_ignore = false
-2025.07.19-20:55:09.21 - <debug> Created top-level rundir: /run/user/0/vaccel/sZDGgp
-2025-07-19 20:55:09.252594: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
-2025-07-19 20:55:09.274317: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
-2025.07.19-20:55:09.27 - <info> Registered plugin tf 0.2.0-4-4c18a4c1
-2025.07.19-20:55:09.27 - <debug> Registered op tf_model_load from plugin tf
-2025.07.19-20:55:09.27 - <debug> Registered op tf_model_unload from plugin tf
-2025.07.19-20:55:09.27 - <debug> Registered op tf_model_run from plugin tf
-2025.07.19-20:55:09.27 - <debug> Registered op tflite_model_load from plugin tf
-2025.07.19-20:55:09.27 - <debug> Registered op tflite_model_unload from plugin tf
-2025.07.19-20:55:09.27 - <debug> Registered op tflite_model_run from plugin tf
-2025.07.19-20:55:09.27 - <debug> Loaded plugin tf from libvaccel-tf.so
-2025.07.19-20:55:09.27 - <debug> Initialized resource 1
+2026-04-29 15:13:10.336778: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
+2026-04-29 15:13:10.358481: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
+2026.04.29-15:13:10.26 - <debug> Initializing vAccel
+2026.04.29-15:13:10.26 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-15:13:10.26 - <debug> Config:
+2026.04.29-15:13:10.26 - <debug>   plugins = libvaccel-tf.so
+2026.04.29-15:13:10.26 - <debug>   log_level = debug
+2026.04.29-15:13:10.26 - <debug>   log_file = (null)
+2026.04.29-15:13:10.26 - <debug>   profiling_enabled = false
+2026.04.29-15:13:10.26 - <debug>   version_ignore = false
+2026.04.29-15:13:10.26 - <debug> Created top-level rundir: /run/user/0/vaccel/9QDV7g
+2026.04.29-15:13:10.36 - <info> Registered plugin tf 0.2.0-22-b9061d01
+2026.04.29-15:13:10.36 - <debug> Registered op tf_model_load from plugin tf
+2026.04.29-15:13:10.36 - <debug> Registered op tf_model_unload from plugin tf
+2026.04.29-15:13:10.36 - <debug> Registered op tf_model_run from plugin tf
+2026.04.29-15:13:10.36 - <debug> Registered op tflite_model_load from plugin tf
+2026.04.29-15:13:10.36 - <debug> Registered op tflite_model_unload from plugin tf
+2026.04.29-15:13:10.36 - <debug> Registered op tflite_model_run from plugin tf
+2026.04.29-15:13:10.36 - <debug> Loaded plugin tf from libvaccel-tf.so
+2026.04.29-15:13:10.36 - <debug> Initialized resource 1
 Initialized model resource 1
-2025.07.19-20:55:09.27 - <debug> New rundir for session 1: /run/user/0/vaccel/sZDGgp/session.1
-2025.07.19-20:55:09.27 - <debug> Initialized session 1
+2026.04.29-15:13:10.36 - <debug> New rundir for session 1: /run/user/0/vaccel/9QDV7g/session.1
+2026.04.29-15:13:10.36 - <debug> Initialized session 1 with plugin tf
 Initialized vAccel session 1
-2025.07.19-20:55:09.27 - <debug> New rundir for resource 1: /run/user/0/vaccel/sZDGgp/resource.1
-2025.07.19-20:55:09.27 - <debug> Downloading https://s3.nbfc.io/models/tf/resnet18-v2-7_saved_model.tar.xz
-2025.07.19-20:55:10.56 - <debug> Downloaded: 41.0 MB of 41.0 MB (100.0%) | Speed: 31.91 MB/sec
-2025.07.19-20:55:10.56 - <debug> Download completed successfully
-2025.07.19-20:55:10.56 - <debug> session:1 Registered resource 1
-2025.07.19-20:55:10.56 - <debug> session:1 Looking for plugin implementing op tf_model_load
-2025.07.19-20:55:10.56 - <debug> Returning func from hint plugin tf
-2025.07.19-20:55:10.56 - <debug> Found implementation in tf plugin
-2025.07.19-20:55:10.56 - <debug> [tf] Loading session from SavedModel
-2025.07.19-20:55:10.57 - <debug> [tf][archive] Extracting: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/
-2025.07.19-20:55:10.57 - <debug> [tf][archive] Extracting: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/assets/
-2025.07.19-20:55:10.57 - <debug> [tf][archive] Extracting: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/fingerprint.pb
-2025.07.19-20:55:10.57 - <debug> [tf][archive] Extracting: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/saved_model.pb
-2025.07.19-20:55:12.64 - <debug> [tf][archive] Extracting: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/variables/
-2025.07.19-20:55:12.64 - <debug> [tf][archive] Extracting: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/variables/variables.data-00000-of-00001
-2025.07.19-20:55:12.64 - <debug> [tf][archive] Extracting: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/variables/variables.index
-2025-07-19 20:55:12.648567: I tensorflow/cc/saved_model/reader.cc:83] Reading SavedModel from: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model
-2025-07-19 20:55:12.668441: I tensorflow/cc/saved_model/reader.cc:52] Reading meta graph with tags { serve }
-2025-07-19 20:55:12.668473: I tensorflow/cc/saved_model/reader.cc:147] Reading SavedModel debug info (if present) from: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model
-2025-07-19 20:55:12.668536: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
+2026.04.29-15:13:10.36 - <debug> New rundir for resource 1: /run/user/0/vaccel/9QDV7g/resource.1
+2026.04.29-15:13:10.36 - <debug> Downloading https://s3.nbfc.io/models/tf/resnet18-v2-7_saved_model.tar.xz
+2026.04.29-15:13:11.40 - <debug> Downloaded: 41.0 MB of 41.0 MB (100.0%) | Speed: 39.37 MB/sec
+2026.04.29-15:13:11.40 - <debug> Download completed successfully
+2026.04.29-15:13:11.40 - <debug> session:1 Registered resource 1
+2026.04.29-15:13:11.40 - <debug> session:1 Looking for func implementing op tf_model_load
+2026.04.29-15:13:11.40 - <debug> Returning func for op tf_model_load from plugin tf
+2026.04.29-15:13:13.52 - <debug> [tf] Loading session from SavedModel
+2026.04.29-15:13:13.53 - <debug> [tf] Extracting: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/
+2026.04.29-15:13:13.53 - <debug> [tf] Extracting: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/assets/
+2026.04.29-15:13:13.53 - <debug> [tf] Extracting: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/fingerprint.pb
+2026.04.29-15:13:13.53 - <debug> [tf] Extracting: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/saved_model.pb
+2026.04.29-15:13:15.66 - <debug> [tf] Extracting: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/variables/
+2026.04.29-15:13:15.66 - <debug> [tf] Extracting: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/variables/variables.data-00000-of-00001
+2026.04.29-15:13:15.66 - <debug> [tf] Extracting: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/variables/variables.index
+2026-04-29 15:13:15.669831: I tensorflow/cc/saved_model/reader.cc:83] Reading SavedModel from: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model
+2026-04-29 15:13:15.690971: I tensorflow/cc/saved_model/reader.cc:52] Reading meta graph with tags { serve }
+2026-04-29 15:13:15.691028: I tensorflow/cc/saved_model/reader.cc:147] Reading SavedModel debug info (if present) from: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model
+2026-04-29 15:13:15.691160: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
 To enable the following instructions: SSE3 SSE4.1 SSE4.2 AVX AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
-2025-07-19 20:55:12.742341: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:388] MLIR V1 optimization pass is not enabled
-2025-07-19 20:55:12.743065: I tensorflow/cc/saved_model/loader.cc:236] Restoring SavedModel bundle.
-2025-07-19 20:55:12.776518: I tensorflow/cc/saved_model/loader.cc:220] Running initialization op on SavedModel bundle at path: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model
-2025-07-19 20:55:12.806477: I tensorflow/cc/saved_model/loader.cc:462] SavedModel load for tags { serve }; Status: success: OK. Took 157910 microseconds.
-2025.07.19-20:55:12.82 - <debug> [tf] Model loaded correctly
+2026-04-29 15:13:15.777876: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:388] MLIR V1 optimization pass is not enabled
+2026-04-29 15:13:15.778679: I tensorflow/cc/saved_model/loader.cc:236] Restoring SavedModel bundle.
+2026-04-29 15:13:15.815605: I tensorflow/cc/saved_model/loader.cc:220] Running initialization op on SavedModel bundle at path: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model
+2026-04-29 15:13:15.849330: I tensorflow/cc/saved_model/loader.cc:462] SavedModel load for tags { serve }; Status: success: OK. Took 179498 microseconds.
+2026.04.29-15:13:15.90 - <debug> [tf] Model loaded correctly
 Session load status => code:0 message:
-2025.07.19-20:55:12.86 - <debug> session:1 Looking for plugin implementing op tf_model_run
-2025.07.19-20:55:12.86 - <debug> Returning func from hint plugin tf
-2025.07.19-20:55:12.86 - <debug> Found implementation in tf plugin
-2025.07.19-20:55:12.86 - <debug> [tf] Running session
-2025.07.19-20:55:13.50 - <debug> [tf] Success
+2026.04.29-15:13:15.91 - <debug> session:1 Looking for func implementing op tf_model_run
+2026.04.29-15:13:15.91 - <debug> Returning func for op tf_model_run from plugin tf
+2026.04.29-15:13:15.91 - <debug> [tf] Running session
+2026.04.29-15:13:16.65 - <debug> [tf] Success
 Session run status => code:0 message:
 Success!
 Output tensor => type:1 nr_dims:2 size:4000B
 Prediction: banana
-2025.07.19-20:55:13.50 - <debug> session:1 Looking for plugin implementing op tf_model_unload
-2025.07.19-20:55:13.50 - <debug> Returning func from hint plugin tf
-2025.07.19-20:55:13.50 - <debug> Found implementation in tf plugin
-2025.07.19-20:55:13.50 - <debug> [tf] Deleting session
-2025.07.19-20:55:13.50 - <debug> [tf][archive] Removed file: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/fingerprint.pb
-2025.07.19-20:55:13.50 - <debug> [tf][archive] Removed file: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/variables/variables.index
-2025.07.19-20:55:13.50 - <debug> [tf][archive] Removed file: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/variables/variables.data-00000-of-00001
-2025.07.19-20:55:13.50 - <debug> [tf][archive] Removed directory: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/variables
-2025.07.19-20:55:13.51 - <debug> [tf][archive] Removed file: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/saved_model.pb
-2025.07.19-20:55:13.51 - <debug> [tf][archive] Removed directory: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model/assets
-2025.07.19-20:55:13.51 - <debug> [tf][archive] Removed directory: /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model
+2026.04.29-15:13:16.65 - <debug> session:1 Looking for func implementing op tf_model_unload
+2026.04.29-15:13:16.65 - <debug> Returning func for op tf_model_unload from plugin tf
+2026.04.29-15:13:16.65 - <debug> [tf] Deleting session
+2026.04.29-15:13:16.66 - <debug> [tf] Removed file: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/fingerprint.pb
+2026.04.29-15:13:16.66 - <debug> [tf] Removed file: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/variables/variables.index
+2026.04.29-15:13:16.66 - <debug> [tf] Removed file: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/variables/variables.data-00000-of-00001
+2026.04.29-15:13:16.66 - <debug> [tf] Removed directory: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/variables
+2026.04.29-15:13:16.66 - <debug> [tf] Removed file: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/saved_model.pb
+2026.04.29-15:13:16.66 - <debug> [tf] Removed directory: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model/assets
+2026.04.29-15:13:16.66 - <debug> [tf] Removed directory: /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model
 Session delete status => code:0 message:
-2025.07.19-20:55:13.51 - <debug> session:1 Unregistered resource 1
-2025.07.19-20:55:13.51 - <debug> Released session 1
-2025.07.19-20:55:13.51 - <debug> Removing file /run/user/0/vaccel/sZDGgp/resource.1/resnet18-v2-7_saved_model.tar.xz
-2025.07.19-20:55:13.51 - <debug> Released resource 1
-2025.07.19-20:55:13.51 - <debug> Cleaning up vAccel
-2025.07.19-20:55:13.51 - <debug> Cleaning up sessions
-2025.07.19-20:55:13.51 - <debug> Cleaning up resources
-2025.07.19-20:55:13.51 - <debug> Cleaning up plugins
-2025.07.19-20:55:13.51 - <debug> Unregistered plugin tf
+2026.04.29-15:13:16.66 - <debug> session:1 Unregistered resource 1
+2026.04.29-15:13:16.66 - <debug> Released session 1
+2026.04.29-15:13:16.66 - <debug> Removing file /run/user/0/vaccel/9QDV7g/resource.1/resnet18-v2-7_saved_model.tar.xz
+2026.04.29-15:13:16.67 - <debug> Released resource 1
+2026.04.29-15:13:16.67 - <debug> Cleaning up vAccel
+2026.04.29-15:13:16.67 - <debug> Cleaning up sessions
+2026.04.29-15:13:16.67 - <debug> Cleaning up resources
+2026.04.29-15:13:16.67 - <debug> Cleaning up plugins
+2026.04.29-15:13:16.67 - <debug> Unregistered plugin tf
 ```
 
 You can also run a similar inference example using Tensorflow Lite with:
@@ -208,61 +205,58 @@ $ tflite_inference \
       /usr/local/share/vaccel/images/example.jpg \
       https://s3.nbfc.io/models/tf/resnet18-v2-7_float32.tflite \
       /usr/local/share/vaccel/labels/imagenet.txt
-2025.07.19-20:55:13.54 - <debug> Initializing vAccel
-2025.07.19-20:55:13.54 - <info> vAccel 0.7.1-22-edced930
-2025.07.19-20:55:13.54 - <debug> Config:
-2025.07.19-20:55:13.54 - <debug>   plugins = libvaccel-tf.so
-2025.07.19-20:55:13.54 - <debug>   log_level = debug
-2025.07.19-20:55:13.54 - <debug>   log_file = (null)
-2025.07.19-20:55:13.54 - <debug>   profiling_enabled = false
-2025.07.19-20:55:13.54 - <debug>   version_ignore = false
-2025.07.19-20:55:13.54 - <debug> Created top-level rundir: /run/user/0/vaccel/hsuZdP
-2025-07-19 20:55:13.568854: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
-2025-07-19 20:55:13.595803: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
-2025.07.19-20:55:13.59 - <info> Registered plugin tf 0.2.0-4-4c18a4c1
-2025.07.19-20:55:13.59 - <debug> Registered op tf_model_load from plugin tf
-2025.07.19-20:55:13.59 - <debug> Registered op tf_model_unload from plugin tf
-2025.07.19-20:55:13.59 - <debug> Registered op tf_model_run from plugin tf
-2025.07.19-20:55:13.59 - <debug> Registered op tflite_model_load from plugin tf
-2025.07.19-20:55:13.59 - <debug> Registered op tflite_model_unload from plugin tf
-2025.07.19-20:55:13.59 - <debug> Registered op tflite_model_run from plugin tf
-2025.07.19-20:55:13.59 - <debug> Loaded plugin tf from libvaccel-tf.so
-2025.07.19-20:55:13.59 - <debug> Initialized resource 1
+2026-04-29 15:14:03.525122: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
+2026-04-29 15:14:03.546097: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
+2026.04.29-15:14:03.49 - <debug> Initializing vAccel
+2026.04.29-15:14:03.49 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-15:14:03.49 - <debug> Config:
+2026.04.29-15:14:03.49 - <debug>   plugins = libvaccel-tf.so
+2026.04.29-15:14:03.49 - <debug>   log_level = debug
+2026.04.29-15:14:03.49 - <debug>   log_file = (null)
+2026.04.29-15:14:03.49 - <debug>   profiling_enabled = false
+2026.04.29-15:14:03.49 - <debug>   version_ignore = false
+2026.04.29-15:14:03.49 - <debug> Created top-level rundir: /run/user/0/vaccel/NFiJEK
+2026.04.29-15:14:03.54 - <info> Registered plugin tf 0.2.0-22-b9061d01
+2026.04.29-15:14:03.54 - <debug> Registered op tf_model_load from plugin tf
+2026.04.29-15:14:03.54 - <debug> Registered op tf_model_unload from plugin tf
+2026.04.29-15:14:03.54 - <debug> Registered op tf_model_run from plugin tf
+2026.04.29-15:14:03.54 - <debug> Registered op tflite_model_load from plugin tf
+2026.04.29-15:14:03.54 - <debug> Registered op tflite_model_unload from plugin tf
+2026.04.29-15:14:03.54 - <debug> Registered op tflite_model_run from plugin tf
+2026.04.29-15:14:03.54 - <debug> Loaded plugin tf from libvaccel-tf.so
+2026.04.29-15:14:03.54 - <debug> Initialized resource 1
 Initialized model resource 1
-2025.07.19-20:55:13.59 - <debug> New rundir for session 1: /run/user/0/vaccel/hsuZdP/session.1
-2025.07.19-20:55:13.59 - <debug> Initialized session 1
+2026.04.29-15:14:03.54 - <debug> New rundir for session 1: /run/user/0/vaccel/NFiJEK/session.1
+2026.04.29-15:14:03.54 - <debug> Initialized session 1 with plugin tf
 Initialized vAccel session 1
-2025.07.19-20:55:13.59 - <debug> New rundir for resource 1: /run/user/0/vaccel/hsuZdP/resource.1
-2025.07.19-20:55:13.59 - <debug> Downloading https://s3.nbfc.io/models/tf/resnet18-v2-7_float32.tflite
-2025.07.19-20:55:14.72 - <debug> Downloaded: 44.6 MB of 44.6 MB (100.0%) | Speed: 39.69 MB/sec
-2025.07.19-20:55:14.72 - <debug> Download completed successfully
-2025.07.19-20:55:14.72 - <debug> session:1 Registered resource 1
-2025.07.19-20:55:14.72 - <debug> session:1 Looking for plugin implementing op tflite_model_load
-2025.07.19-20:55:14.72 - <debug> Returning func from hint plugin tf
-2025.07.19-20:55:14.72 - <debug> Found implementation in tf plugin
-2025.07.19-20:55:14.72 - <debug> [tf][tflite] Loading session from model
-2025.07.19-20:55:14.72 - <debug> [tf][tflite] Model loaded correctly
-2025.07.19-20:55:14.73 - <debug> session:1 Looking for plugin implementing op tflite_model_run
-2025.07.19-20:55:14.73 - <debug> Returning func from hint plugin tf
-2025.07.19-20:55:14.73 - <debug> Found implementation in tf plugin
-2025.07.19-20:55:14.73 - <debug> [tf][tflite] Running session
-2025.07.19-20:55:14.83 - <debug> [tf][tflite] Success
+2026.04.29-15:14:03.54 - <debug> New rundir for resource 1: /run/user/0/vaccel/NFiJEK/resource.1
+2026.04.29-15:14:03.54 - <debug> Downloading https://s3.nbfc.io/models/tf/resnet18-v2-7_float32.tflite
+2026.04.29-15:14:04.73 - <debug> Downloaded: 44.6 MB of 44.6 MB (100.0%) | Speed: 37.63 MB/sec
+2026.04.29-15:14:04.73 - <debug> Download completed successfully
+2026.04.29-15:14:04.73 - <debug> session:1 Registered resource 1
+2026.04.29-15:14:04.73 - <debug> session:1 Looking for func implementing op tflite_model_load
+2026.04.29-15:14:04.73 - <debug> Returning func for op tflite_model_load from plugin tf
+2026.04.29-15:14:04.73 - <debug> [tf][tflite] Loading session from model
+2026.04.29-15:14:04.73 - <debug> [tf][tflite] Model loaded correctly
+2026.04.29-15:14:04.74 - <debug> session:1 Looking for func implementing op tflite_model_run
+2026.04.29-15:14:04.74 - <debug> Returning func for op tflite_model_run from plugin tf
+2026.04.29-15:14:04.74 - <debug> [tf][tflite] Running session
+2026.04.29-15:14:04.84 - <debug> [tf][tflite] Success
 Session run status: 0
 Success!
 Output tensor => type:1 nr_dims:2 size:4000B
 Prediction: banana
-2025.07.19-20:55:14.83 - <debug> session:1 Looking for plugin implementing op tflite_model_unload
-2025.07.19-20:55:14.83 - <debug> Returning func from hint plugin tf
-2025.07.19-20:55:14.83 - <debug> Found implementation in tf plugin
-2025.07.19-20:55:14.83 - <debug> session:1 Unregistered resource 1
-2025.07.19-20:55:14.83 - <debug> Released session 1
-2025.07.19-20:55:14.83 - <debug> Removing file /run/user/0/vaccel/hsuZdP/resource.1/resnet18-v2-7_float32.tflite
-2025.07.19-20:55:14.83 - <debug> Released resource 1
-2025.07.19-20:55:14.83 - <debug> Cleaning up vAccel
-2025.07.19-20:55:14.83 - <debug> Cleaning up sessions
-2025.07.19-20:55:14.83 - <debug> Cleaning up resources
-2025.07.19-20:55:14.83 - <debug> Cleaning up plugins
-2025.07.19-20:55:14.83 - <debug> Unregistered plugin tf
+2026.04.29-15:14:04.84 - <debug> session:1 Looking for func implementing op tflite_model_unload
+2026.04.29-15:14:04.84 - <debug> Returning func for op tflite_model_unload from plugin tf
+2026.04.29-15:14:04.84 - <debug> session:1 Unregistered resource 1
+2026.04.29-15:14:04.84 - <debug> Released session 1
+2026.04.29-15:14:04.84 - <debug> Removing file /run/user/0/vaccel/NFiJEK/resource.1/resnet18-v2-7_float32.tflite
+2026.04.29-15:14:04.85 - <debug> Released resource 1
+2026.04.29-15:14:04.85 - <debug> Cleaning up vAccel
+2026.04.29-15:14:04.85 - <debug> Cleaning up sessions
+2026.04.29-15:14:04.85 - <debug> Cleaning up resources
+2026.04.29-15:14:04.85 - <debug> Cleaning up plugins
+2026.04.29-15:14:04.85 - <debug> Unregistered plugin tf
 ```
 
 ## Using the vAccel Tensorflow bindings

--- a/docs/plugins/available-plugins/acceleration-plugins/torch-plugin.md
+++ b/docs/plugins/available-plugins/acceleration-plugins/torch-plugin.md
@@ -123,45 +123,49 @@ with:
 ```console
 $ classify /usr/local/share/vaccel/images/example.jpg 1 \
       https://s3.nbfc.io/torch/resnet18.pt
-2025.04.11-15:46:20.07 - <debug> Initializing vAccel
-2025.04.11-15:46:20.07 - <info> vAccel 0.6.1-194-19056528
-2025.04.11-15:46:20.07 - <debug> Config:
-2025.04.11-15:46:20.07 - <debug>   plugins = libvaccel-torch.so
-2025.04.11-15:46:20.07 - <debug>   log_level = debug
-2025.04.11-15:46:20.07 - <debug>   log_file = (null)
-2025.04.11-15:46:20.07 - <debug>   profiling_enabled = false
-2025.04.11-15:46:20.07 - <debug>   version_ignore = false
-2025.04.11-15:46:20.07 - <debug> Created top-level rundir: /run/user/1002/vaccel/w8BHSP
-2025.04.11-15:46:20.53 - <info> Registered plugin torch 0.1.0-25-ab85fa03
-2025.04.11-15:46:20.53 - <debug> Registered op torch_jitload_forward from plugin torch
-2025.04.11-15:46:20.53 - <debug> Registered op torch_sgemm from plugin torch
-2025.04.11-15:46:20.53 - <debug> Registered op image_classify from plugin torch
-2025.04.11-15:46:20.53 - <debug> Loaded plugin torch from libvaccel-torch.so
-2025.04.11-15:46:20.53 - <debug> New rundir for session 1: /run/user/1002/vaccel/w8BHSP/session.1
-2025.04.11-15:46:20.53 - <debug> Initialized session 1
+2026.04.29-15:19:39.63 - <debug> Initializing vAccel
+2026.04.29-15:19:39.63 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-15:19:39.63 - <debug> Config:
+2026.04.29-15:19:39.63 - <debug>   plugins = libvaccel-torch.so
+2026.04.29-15:19:39.63 - <debug>   log_level = debug
+2026.04.29-15:19:39.63 - <debug>   log_file = (null)
+2026.04.29-15:19:39.63 - <debug>   profiling_enabled = false
+2026.04.29-15:19:39.63 - <debug>   version_ignore = false
+2026.04.29-15:19:39.74 - <debug> Created top-level rundir: /run/user/0/vaccel/uscxgC
+2026.04.29-15:19:39.95 - <info> Registered plugin torch 0.2.1-27-abc7d840
+2026.04.29-15:19:39.95 - <debug> Registered op torch_model_load from plugin torch
+2026.04.29-15:19:39.95 - <debug> Registered op torch_model_run from plugin torch
+2026.04.29-15:19:39.95 - <debug> Registered op torch_sgemm from plugin torch
+2026.04.29-15:19:39.95 - <debug> Registered op image_classify from plugin torch
+2026.04.29-15:19:39.95 - <debug> Loaded plugin torch from libvaccel-torch.so
+2026.04.29-15:19:39.95 - <debug> New rundir for session 1: /run/user/0/vaccel/uscxgC/session.1
+2026.04.29-15:19:39.95 - <debug> Initialized session 1 with plugin torch
 Initialized session with id: 1
-2025.04.11-15:46:20.53 - <debug> Initialized resource 1
-2025.04.11-15:46:20.53 - <debug> New rundir for resource 1: /run/user/1002/vaccel/w8BHSP/resource.1
-2025.04.11-15:46:20.53 - <debug> Downloading https://s3.nbfc.io/torch/resnet18.pt
-...
-2025.04.11-15:48:41.53 - <debug> Download completed successfully
-2025.04.11-15:48:41.53 - <debug> session:1 Registered resource 1
-2025.04.11-15:48:41.53 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.11-15:48:41.53 - <debug> Returning func from hint plugin torch
-2025.04.11-15:48:41.53 - <debug> Found implementation in torch plugin
-2025.04.11-15:48:41.73 - <debug> [torch] Model loaded successfully from: /run/user/1002/vaccel/w8BHSP/resource.1/resnet18.pt
-2025.04.11-15:48:41.89 - <debug> [torch] Prediction: banana
+2026.04.29-15:19:39.95 - <debug> Initialized resource 1
+2026.04.29-15:19:39.95 - <debug> New rundir for resource 1: /run/user/0/vaccel/uscxgC/resource.1
+2026.04.29-15:19:39.95 - <debug> Downloading https://s3.nbfc.io/torch/resnet18.pt
+2026.04.29-15:19:40.99 - <debug> Downloaded: 44.7 MB of 44.7 MB (100.0%) | Speed: 43.19 MB/sec
+2026.04.29-15:19:40.99 - <debug> Download completed successfully
+2026.04.29-15:19:40.99 - <debug> session:1 Registered resource 1
+2026.04.29-15:19:40.99 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.29-15:19:40.99 - <debug> Returning func for op image_classify from plugin torch
+2026.04.29-15:19:40.99 - <warn> [torch] Registered model is not loaded; loading...
+2026.04.29-15:19:40.99 - <debug> [torch] Running in CPU mode
+2026.04.29-15:19:40.99 - <debug> [torch] Loading model from /run/user/0/vaccel/uscxgC/resource.1/resnet18.pt
+2026.04.29-15:19:41.05 - <debug> [torch] Loaded registered model
+2026.04.29-15:19:41.06 - <debug> [torch] Disabling graph executor optimization
+2026.04.29-15:19:41.09 - <debug> [torch] Prediction: banana 87.34%
 classification tags: banana
 classification imagename: PLACEHOLDER
-2025.04.11-15:48:41.91 - <debug> session:1 Unregistered resource 1
-2025.04.11-15:48:41.91 - <debug> Removing file /run/user/1002/vaccel/w8BHSP/resource.1/resnet18.pt
-2025.04.11-15:48:41.92 - <debug> Released resource 1
-2025.04.11-15:48:41.92 - <debug> Released session 1
-2025.04.11-15:48:42.06 - <debug> Cleaning up vAccel
-2025.04.11-15:48:42.06 - <debug> Cleaning up sessions
-2025.04.11-15:48:42.06 - <debug> Cleaning up resources
-2025.04.11-15:48:42.06 - <debug> Cleaning up plugins
-2025.04.11-15:48:42.06 - <debug> Unregistered plugin torch
+2026.04.29-15:19:41.09 - <debug> session:1 Unregistered resource 1
+2026.04.29-15:19:41.09 - <debug> Removing file /run/user/0/vaccel/uscxgC/resource.1/resnet18.pt
+2026.04.29-15:19:41.10 - <debug> Released resource 1
+2026.04.29-15:19:41.10 - <debug> Released session 1
+2026.04.29-15:19:41.16 - <debug> Cleaning up vAccel
+2026.04.29-15:19:41.16 - <debug> Cleaning up sessions
+2026.04.29-15:19:41.16 - <debug> Cleaning up resources
+2026.04.29-15:19:41.16 - <debug> Cleaning up plugins
+2026.04.29-15:19:41.16 - <debug> Unregistered plugin torch
 ```
 
 To run a torch inference example with the generic `jitload_forward` operation:
@@ -170,48 +174,51 @@ To run a torch inference example with the generic `jitload_forward` operation:
 $ torch_inference /usr/local/share/vaccel/images/example.jpg \
       https://s3.nbfc.io/torch/resnet18.pt \
       "${VACCEL_TORCH_LABELS}"
-2025.04.11-15:59:42.95 - <debug> Initializing vAccel
-2025.04.11-15:59:42.95 - <info> vAccel 0.6.1-194-19056528
-2025.04.11-15:59:42.95 - <debug> Config:
-2025.04.11-15:59:42.95 - <debug>   plugins = libvaccel-torch.so
-2025.04.11-15:59:42.95 - <debug>   log_level = debug
-2025.04.11-15:59:42.95 - <debug>   log_file = (null)
-2025.04.11-15:59:42.95 - <debug>   profiling_enabled = false
-2025.04.11-15:59:42.95 - <debug>   version_ignore = false
-2025.04.11-15:59:42.95 - <debug> Created top-level rundir: /run/user/1002/vaccel/fEe2aO
-2025.04.11-15:59:43.41 - <info> Registered plugin torch 0.1.0-25-ab85fa03
-2025.04.11-15:59:43.41 - <debug> Registered op torch_jitload_forward from plugin torch
-2025.04.11-15:59:43.41 - <debug> Registered op torch_sgemm from plugin torch
-2025.04.11-15:59:43.41 - <debug> Registered op image_classify from plugin torch
-2025.04.11-15:59:43.41 - <debug> Loaded plugin torch from libvaccel-torch.so
-2025.04.11-15:59:43.41 - <debug> Initialized resource 1
+2026.04.29-15:19:57.82 - <debug> Initializing vAccel
+2026.04.29-15:19:57.82 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-15:19:57.82 - <debug> Config:
+2026.04.29-15:19:57.82 - <debug>   plugins = libvaccel-torch.so
+2026.04.29-15:19:57.82 - <debug>   log_level = debug
+2026.04.29-15:19:57.82 - <debug>   log_file = (null)
+2026.04.29-15:19:57.82 - <debug>   profiling_enabled = false
+2026.04.29-15:19:57.82 - <debug>   version_ignore = false
+2026.04.29-15:19:57.82 - <debug> Created top-level rundir: /run/user/0/vaccel/d2iSTG
+2026.04.29-15:19:58.01 - <info> Registered plugin torch 0.2.1-27-abc7d840
+2026.04.29-15:19:58.01 - <debug> Registered op torch_model_load from plugin torch
+2026.04.29-15:19:58.01 - <debug> Registered op torch_model_run from plugin torch
+2026.04.29-15:19:58.01 - <debug> Registered op torch_sgemm from plugin torch
+2026.04.29-15:19:58.01 - <debug> Registered op image_classify from plugin torch
+2026.04.29-15:19:58.01 - <debug> Loaded plugin torch from libvaccel-torch.so
+2026.04.29-15:19:58.01 - <debug> Initialized resource 1
 Initialized model resource 1
-2025.04.11-15:59:43.41 - <debug> New rundir for session 1: /run/user/1002/vaccel/fEe2aO/session.1
-2025.04.11-15:59:43.41 - <debug> Initialized session 1
+2026.04.29-15:19:58.01 - <debug> New rundir for session 1: /run/user/0/vaccel/d2iSTG/session.1
+2026.04.29-15:19:58.01 - <debug> Initialized session 1 with plugin torch
 Initialized vAccel session 1
-2025.04.11-15:59:43.41 - <debug> New rundir for resource 1: /run/user/1002/vaccel/fEe2aO/resource.1
-2025.04.11-15:59:43.41 - <debug> Downloading https://s3.nbfc.io/torch/resnet18.pt
-...
-2025.04.11-16:05:21.23 - <debug> Download completed successfully
-2025.04.11-16:05:21.23 - <debug> session:1 Registered resource 1
-2025.04.11-16:05:21.27 - <debug> session:1 Looking for plugin implementing torch_jitload_forward operation
-2025.04.11-16:05:21.27 - <debug> Returning func from hint plugin torch
-2025.04.11-16:05:21.27 - <debug> Found implementation in torch plugin
-2025.04.11-16:05:21.27 - <debug> [torch] session:1 Jitload & Forward Process
-2025.04.11-16:05:21.27 - <debug> [torch] Model: /run/user/1002/vaccel/1nB5aC/resource.1/resnet18.pt
-2025.04.11-16:05:21.27 - <debug> [torch] CUDA not available, running in CPU mode
+2026.04.29-15:19:58.01 - <debug> New rundir for resource 1: /run/user/0/vaccel/d2iSTG/resource.1
+2026.04.29-15:19:58.01 - <debug> Downloading https://s3.nbfc.io/torch/resnet18.pt
+2026.04.29-15:19:59.04 - <debug> Downloaded: 44.7 MB of 44.7 MB (100.0%) | Speed: 43.19 MB/sec
+2026.04.29-15:19:59.04 - <debug> Download completed successfully
+2026.04.29-15:19:59.04 - <debug> session:1 Registered resource 1
+2026.04.29-15:19:59.04 - <debug> session:1 Looking for func implementing op torch_model_load
+2026.04.29-15:19:59.04 - <debug> Returning func for op torch_model_load from plugin torch
+2026.04.29-15:19:59.04 - <debug> [torch] Running in CPU mode
+2026.04.29-15:19:59.05 - <debug> [torch] Loading model from /run/user/0/vaccel/d2iSTG/resource.1/resnet18.pt
+2026.04.29-15:19:59.12 - <debug> session:1 Looking for func implementing op torch_model_run
+2026.04.29-15:19:59.12 - <debug> Returning func for op torch_model_run from plugin torch
+2026.04.29-15:19:59.12 - <debug> [torch] session:1 Jitload & Forward Process
+2026.04.29-15:19:59.12 - <debug> [torch] Model: /run/user/0/vaccel/d2iSTG/resource.1/resnet18.pt
+2026.04.29-15:19:59.12 - <debug> [torch] Disabling graph executor optimization
 Success!
 Result Tensor :
-Output tensor => type:7 nr_dims:2
-size: 4000 B
+Output tensor => type:7 nr_dims:2 size:4000B
 Prediction: banana
-2025.04.11-16:05:21.50 - <debug> session:1 Unregistered resource 1
-2025.04.11-16:05:21.50 - <debug> Released session 1
-2025.04.11-16:05:21.50 - <debug> Removing file /run/user/1002/vaccel/1nB5aC/resource.1/resnet18.pt
-2025.04.11-16:05:21.51 - <debug> Released resource 1
-2025.04.11-16:05:21.61 - <debug> Cleaning up vAccel
-2025.04.11-16:05:21.61 - <debug> Cleaning up sessions
-2025.04.11-16:05:21.61 - <debug> Cleaning up resources
-2025.04.11-16:05:21.61 - <debug> Cleaning up plugins
-2025.04.11-16:05:21.61 - <debug> Unregistered plugin torch
+2026.04.29-15:19:59.16 - <debug> session:1 Unregistered resource 1
+2026.04.29-15:19:59.16 - <debug> Released session 1
+2026.04.29-15:19:59.16 - <debug> Removing file /run/user/0/vaccel/d2iSTG/resource.1/resnet18.pt
+2026.04.29-15:19:59.17 - <debug> Released resource 1
+2026.04.29-15:19:59.23 - <debug> Cleaning up vAccel
+2026.04.29-15:19:59.23 - <debug> Cleaning up sessions
+2026.04.29-15:19:59.23 - <debug> Cleaning up resources
+2026.04.29-15:19:59.23 - <debug> Cleaning up plugins
+2026.04.29-15:19:59.23 - <debug> Unregistered plugin torch
 ```

--- a/docs/plugins/available-plugins/acceleration-plugins/tvm-plugin.md
+++ b/docs/plugins/available-plugins/acceleration-plugins/tvm-plugin.md
@@ -102,48 +102,43 @@ classification with a ResNet model from
 ```console
 $ classify /usr/local/share/vaccel/images/example.jpg 1 \
       https://s3.nbfc.io/models/tvm/x86_64/resnet18-v2-7.so
-2025.03.25-19:37:03.39 - <debug> Initializing vAccel
-2025.03.25-19:37:03.39 - <info> vAccel 0.6.1-194-19056528
-2025.03.25-19:37:03.39 - <debug> Config:
-2025.03.25-19:37:03.39 - <debug>   plugins = libvaccel-tvm.so
-2025.03.25-19:37:03.39 - <debug>   log_level = debug
-2025.03.25-19:37:03.39 - <debug>   log_file = (null)
-2025.03.25-19:37:03.39 - <debug>   profiling_enabled = false
-2025.03.25-19:37:03.39 - <debug>   version_ignore = false
-2025.03.25-19:37:03.39 - <debug> Created top-level rundir: /run/user/1002/vaccel/7CYHmR
-2025.03.25-19:37:03.40 - <info> Registered plugin tvm 0.0.0-19-d720e616
-2025.03.25-19:37:03.40 - <debug> Registered op image_classify from plugin tvm
-2025.03.25-19:37:03.40 - <debug> Loaded plugin tvm from libvaccel-tvm.so
-2025.03.25-19:37:03.40 - <debug> New rundir for session 1: /run/user/1002/vaccel/7CYHmR/session.1
-2025.03.25-19:37:03.40 - <debug> Initialized session 1
+2026.04.29-15:22:46.01 - <debug> Initializing vAccel
+2026.04.29-15:22:46.01 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-15:22:46.01 - <debug> Config:
+2026.04.29-15:22:46.01 - <debug>   plugins = libvaccel-tvm.so
+2026.04.29-15:22:46.01 - <debug>   log_level = debug
+2026.04.29-15:22:46.01 - <debug>   log_file = (null)
+2026.04.29-15:22:46.01 - <debug>   profiling_enabled = false
+2026.04.29-15:22:46.01 - <debug>   version_ignore = false
+2026.04.29-15:22:46.01 - <debug> Created top-level rundir: /run/user/0/vaccel/sCOIDY
+2026.04.29-15:22:46.01 - <info> Registered plugin tvm 0.1.0-11-6da3ba19
+2026.04.29-15:22:46.01 - <debug> Registered op image_classify from plugin tvm
+2026.04.29-15:22:46.01 - <debug> Loaded plugin tvm from libvaccel-tvm.so
+2026.04.29-15:22:46.01 - <debug> New rundir for session 1: /run/user/0/vaccel/sCOIDY/session.1
+2026.04.29-15:22:46.01 - <debug> Initialized session 1 with plugin tvm
 Initialized session with id: 1
-2025.03.25-19:37:03.40 - <debug> Initialized resource 1
-2025.03.25-19:37:03.40 - <debug> New rundir for resource 1: /run/user/1002/vaccel/7CYHmR/resource.1
-2025.03.25-19:37:03.40 - <debug> Downloading https://s3.nbfc.io/models/tvm/x86_64/resnet18-v2-7.so
-2025.03.25-19:37:08.40 - <debug> Downloaded: 9.0 MB of 45.8 MB (19.7%) | Speed: 1.80 MB/sec
-2025.03.25-19:37:13.40 - <debug> Downloaded: 20.2 MB of 45.8 MB (44.1%) | Speed: 2.02 MB/sec
-2025.03.25-19:37:18.40 - <debug> Downloaded: 31.1 MB of 45.8 MB (67.9%) | Speed: 2.07 MB/sec
-2025.03.25-19:37:23.40 - <debug> Downloaded: 40.2 MB of 45.8 MB (87.8%) | Speed: 2.01 MB/sec
-2025.03.25-19:37:26.28 - <debug> Downloaded: 45.8 MB of 45.8 MB (100.0%) | Speed: 2.00 MB/sec
-2025.03.25-19:37:26.28 - <debug> Download completed successfully
-2025.03.25-19:37:26.28 - <debug> session:1 Registered resource 1
-2025.03.25-19:37:26.28 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.03.25-19:37:26.28 - <debug> Returning func from hint plugin tvm
-2025.03.25-19:37:26.28 - <debug> Found implementation in tvm plugin
-2025.03.25-19:37:26.28 - <debug> [tvm] Resource path: /run/user/1002/vaccel/7CYHmR/resource.1/resnet18-v2-7.so
-loading file: /run/user/1002/vaccel/7CYHmR/resource.1/resnet18-v2-7.so
-2025.03.25-19:37:26.43 - <debug> [tvm] Prediction: banana
+2026.04.29-15:22:46.01 - <debug> Initialized resource 1
+2026.04.29-15:22:46.01 - <debug> New rundir for resource 1: /run/user/0/vaccel/sCOIDY/resource.1
+2026.04.29-15:22:46.01 - <debug> Downloading https://s3.nbfc.io/models/tvm/x86_64/resnet18-v2-7.so
+2026.04.29-15:22:47.36 - <debug> Downloaded: 45.8 MB of 45.8 MB (100.0%) | Speed: 34.00 MB/sec
+2026.04.29-15:22:47.36 - <debug> Download completed successfully
+2026.04.29-15:22:47.36 - <debug> session:1 Registered resource 1
+2026.04.29-15:22:47.36 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.29-15:22:47.36 - <debug> Returning func for op image_classify from plugin tvm
+2026.04.29-15:22:47.36 - <debug> [tvm] Resource path: /run/user/0/vaccel/sCOIDY/resource.1/resnet18-v2-7.so
+loading file: /run/user/0/vaccel/sCOIDY/resource.1/resnet18-v2-7.so
+2026.04.29-15:22:47.47 - <debug> [tvm] Prediction: banana
 classification tags: banana
 classification imagename: PLACEHOLDER
-2025.03.25-19:37:26.43 - <debug> session:1 Unregistered resource 1
-2025.03.25-19:37:26.43 - <debug> Removing file /run/user/1002/vaccel/7CYHmR/resource.1/resnet18-v2-7.so
-2025.03.25-19:37:26.44 - <debug> Released resource 1
-2025.03.25-19:37:26.44 - <debug> Released session 1
-2025.03.25-19:37:26.65 - <debug> Cleaning up vAccel
-2025.03.25-19:37:26.65 - <debug> Cleaning up sessions
-2025.03.25-19:37:26.65 - <debug> Cleaning up resources
-2025.03.25-19:37:26.65 - <debug> Cleaning up plugins
-2025.03.25-19:37:26.65 - <debug> Unregistered plugin tvm
+2026.04.29-15:22:47.47 - <debug> session:1 Unregistered resource 1
+2026.04.29-15:22:47.47 - <debug> Removing file /run/user/0/vaccel/sCOIDY/resource.1/resnet18-v2-7.so
+2026.04.29-15:22:47.47 - <debug> Released resource 1
+2026.04.29-15:22:47.47 - <debug> Released session 1
+2026.04.29-15:22:47.54 - <debug> Cleaning up vAccel
+2026.04.29-15:22:47.54 - <debug> Cleaning up sessions
+2026.04.29-15:22:47.54 - <debug> Cleaning up resources
+2026.04.29-15:22:47.54 - <debug> Cleaning up plugins
+2026.04.29-15:22:47.54 - <debug> Unregistered plugin tvm
 ```
 
 ///
@@ -153,48 +148,43 @@ classification imagename: PLACEHOLDER
 ```console
 $ classify /usr/local/share/vaccel/images/example.jpg 1 \
       https://s3.nbfc.io/models/tvm/aarch64/resnet18-v2-7.so
-2025.03.25-19:37:03.39 - <debug> Initializing vAccel
-2025.03.25-19:37:03.39 - <info> vAccel 0.6.1-194-19056528
-2025.03.25-19:37:03.39 - <debug> Config:
-2025.03.25-19:37:03.39 - <debug>   plugins = libvaccel-tvm.so
-2025.03.25-19:37:03.39 - <debug>   log_level = debug
-2025.03.25-19:37:03.39 - <debug>   log_file = (null)
-2025.03.25-19:37:03.39 - <debug>   profiling_enabled = false
-2025.03.25-19:37:03.39 - <debug>   version_ignore = false
-2025.03.25-19:37:03.39 - <debug> Created top-level rundir: /run/user/1002/vaccel/7CYHmR
-2025.03.25-19:37:03.40 - <info> Registered plugin tvm 0.0.0-19-d720e616
-2025.03.25-19:37:03.40 - <debug> Registered op image_classify from plugin tvm
-2025.03.25-19:37:03.40 - <debug> Loaded plugin tvm from libvaccel-tvm.so
-2025.03.25-19:37:03.40 - <debug> New rundir for session 1: /run/user/1002/vaccel/7CYHmR/session.1
-2025.03.25-19:37:03.40 - <debug> Initialized session 1
+2026.04.29-15:22:46.01 - <debug> Initializing vAccel
+2026.04.29-15:22:46.01 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-15:22:46.01 - <debug> Config:
+2026.04.29-15:22:46.01 - <debug>   plugins = libvaccel-tvm.so
+2026.04.29-15:22:46.01 - <debug>   log_level = debug
+2026.04.29-15:22:46.01 - <debug>   log_file = (null)
+2026.04.29-15:22:46.01 - <debug>   profiling_enabled = false
+2026.04.29-15:22:46.01 - <debug>   version_ignore = false
+2026.04.29-15:22:46.01 - <debug> Created top-level rundir: /run/user/0/vaccel/sCOIDY
+2026.04.29-15:22:46.01 - <info> Registered plugin tvm 0.1.0-11-6da3ba19
+2026.04.29-15:22:46.01 - <debug> Registered op image_classify from plugin tvm
+2026.04.29-15:22:46.01 - <debug> Loaded plugin tvm from libvaccel-tvm.so
+2026.04.29-15:22:46.01 - <debug> New rundir for session 1: /run/user/0/vaccel/sCOIDY/session.1
+2026.04.29-15:22:46.01 - <debug> Initialized session 1 with plugin tvm
 Initialized session with id: 1
-2025.03.25-19:37:03.40 - <debug> Initialized resource 1
-2025.03.25-19:37:03.40 - <debug> New rundir for resource 1: /run/user/1002/vaccel/7CYHmR/resource.1
-2025.03.25-19:37:03.40 - <debug> Downloading https://s3.nbfc.io/models/tvm/x86_64/resnet18-v2-7.so
-2025.03.25-19:37:08.40 - <debug> Downloaded: 9.0 MB of 45.8 MB (19.7%) | Speed: 1.80 MB/sec
-2025.03.25-19:37:13.40 - <debug> Downloaded: 20.2 MB of 45.8 MB (44.1%) | Speed: 2.02 MB/sec
-2025.03.25-19:37:18.40 - <debug> Downloaded: 31.1 MB of 45.8 MB (67.9%) | Speed: 2.07 MB/sec
-2025.03.25-19:37:23.40 - <debug> Downloaded: 40.2 MB of 45.8 MB (87.8%) | Speed: 2.01 MB/sec
-2025.03.25-19:37:26.28 - <debug> Downloaded: 45.8 MB of 45.8 MB (100.0%) | Speed: 2.00 MB/sec
-2025.03.25-19:37:26.28 - <debug> Download completed successfully
-2025.03.25-19:37:26.28 - <debug> session:1 Registered resource 1
-2025.03.25-19:37:26.28 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.03.25-19:37:26.28 - <debug> Returning func from hint plugin tvm
-2025.03.25-19:37:26.28 - <debug> Found implementation in tvm plugin
-2025.03.25-19:37:26.28 - <debug> [tvm] Resource path: /run/user/1002/vaccel/7CYHmR/resource.1/resnet18-v2-7.so
-loading file: /run/user/1002/vaccel/7CYHmR/resource.1/resnet18-v2-7.so
-2025.03.25-19:37:26.43 - <debug> [tvm] Prediction: banana
+2026.04.29-15:22:46.01 - <debug> Initialized resource 1
+2026.04.29-15:22:46.01 - <debug> New rundir for resource 1: /run/user/0/vaccel/sCOIDY/resource.1
+2026.04.29-15:22:46.01 - <debug> Downloading https://s3.nbfc.io/models/tvm/aarch64/resnet18-v2-7.so
+2026.04.29-15:22:47.36 - <debug> Downloaded: 45.8 MB of 45.8 MB (100.0%) | Speed: 34.00 MB/sec
+2026.04.29-15:22:47.36 - <debug> Download completed successfully
+2026.04.29-15:22:47.36 - <debug> session:1 Registered resource 1
+2026.04.29-15:22:47.36 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.29-15:22:47.36 - <debug> Returning func for op image_classify from plugin tvm
+2026.04.29-15:22:47.36 - <debug> [tvm] Resource path: /run/user/0/vaccel/sCOIDY/resource.1/resnet18-v2-7.so
+loading file: /run/user/0/vaccel/sCOIDY/resource.1/resnet18-v2-7.so
+2026.04.29-15:22:47.47 - <debug> [tvm] Prediction: banana
 classification tags: banana
 classification imagename: PLACEHOLDER
-2025.03.25-19:37:26.43 - <debug> session:1 Unregistered resource 1
-2025.03.25-19:37:26.43 - <debug> Removing file /run/user/1002/vaccel/7CYHmR/resource.1/resnet18-v2-7.so
-2025.03.25-19:37:26.44 - <debug> Released resource 1
-2025.03.25-19:37:26.44 - <debug> Released session 1
-2025.03.25-19:37:26.65 - <debug> Cleaning up vAccel
-2025.03.25-19:37:26.65 - <debug> Cleaning up sessions
-2025.03.25-19:37:26.65 - <debug> Cleaning up resources
-2025.03.25-19:37:26.65 - <debug> Cleaning up plugins
-2025.03.25-19:37:26.65 - <debug> Unregistered plugin tvm
+2026.04.29-15:22:47.47 - <debug> session:1 Unregistered resource 1
+2026.04.29-15:22:47.47 - <debug> Removing file /run/user/0/vaccel/sCOIDY/resource.1/resnet18-v2-7.so
+2026.04.29-15:22:47.47 - <debug> Released resource 1
+2026.04.29-15:22:47.47 - <debug> Released session 1
+2026.04.29-15:22:47.54 - <debug> Cleaning up vAccel
+2026.04.29-15:22:47.54 - <debug> Cleaning up sessions
+2026.04.29-15:22:47.54 - <debug> Cleaning up resources
+2026.04.29-15:22:47.54 - <debug> Cleaning up plugins
+2026.04.29-15:22:47.54 - <debug> Unregistered plugin tvm
 ```
 
 ///

--- a/docs/plugins/available-plugins/bundled-plugins/exec-plugin.md
+++ b/docs/plugins/available-plugins/bundled-plugins/exec-plugin.md
@@ -47,72 +47,70 @@ Assuming `pkg-config` is available, you can call `mytestfunc` from the provided
 `libmytestlib.so` with:
 
 ```console
-$ exec_with_res "$(pkg-config --variable=libdir vaccel)/libmytestlib.so"
-2025.04.15-19:37:37.77 - <debug> Initializing vAccel
-2025.04.15-19:37:37.77 - <info> vAccel 0.6.1-194-19056528
-2025.04.15-19:37:37.77 - <debug> Config:
-2025.04.15-19:37:37.77 - <debug>   plugins = libvaccel-exec.so
-2025.04.15-19:37:37.77 - <debug>   log_level = debug
-2025.04.15-19:37:37.77 - <debug>   log_file = (null)
-2025.04.15-19:37:37.77 - <debug>   profiling_enabled = false
-2025.04.15-19:37:37.77 - <debug>   version_ignore = false
-2025.04.15-19:37:37.77 - <debug> Created top-level rundir: /run/user/1002/vaccel/DYBt4h
-2025.04.15-19:37:37.77 - <info> Registered plugin exec 0.6.1-194-19056528
-2025.04.15-19:37:37.77 - <debug> Registered op noop from plugin exec
-2025.04.15-19:37:37.77 - <debug> Registered op exec from plugin exec
-2025.04.15-19:37:37.77 - <debug> Registered op exec_with_resource from plugin exec
-2025.04.15-19:37:37.77 - <debug> Loaded plugin exec from libvaccel-exec.so
-2025.04.15-19:37:37.77 - <warn> Path does not seem to have a `<prefix>://`
-2025.04.15-19:37:37.77 - <warn> Assuming /usr/local/lib/x86_64-linux-gnu/libmytestlib.so is a local path
-2025.04.15-19:37:37.77 - <debug> Initialized resource 1
-2025.04.15-19:37:37.77 - <debug> New rundir for session 1: /run/user/1002/vaccel/DYBt4h/session.1
-2025.04.15-19:37:37.77 - <debug> Initialized session 1
+$ exec_with_resource "$(pkg-config --variable=libdir vaccel)/libmytestlib.so"
+2026.04.29-14:45:52.60 - <debug> Initializing vAccel
+2026.04.29-14:45:52.60 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-14:45:52.60 - <debug> Config:
+2026.04.29-14:45:52.60 - <debug>   plugins = libvaccel-exec.so
+2026.04.29-14:45:52.60 - <debug>   log_level = debug
+2026.04.29-14:45:52.60 - <debug>   log_file = (null)
+2026.04.29-14:45:52.60 - <debug>   profiling_enabled = false
+2026.04.29-14:45:52.60 - <debug>   version_ignore = false
+2026.04.29-14:45:52.60 - <debug> Created top-level rundir: /run/user/0/vaccel/WHJlSC
+2026.04.29-14:45:52.60 - <info> Registered plugin exec 0.7.1-93-ebc23b1f
+2026.04.29-14:45:52.60 - <debug> Registered op noop from plugin exec
+2026.04.29-14:45:52.60 - <debug> Registered op exec from plugin exec
+2026.04.29-14:45:52.60 - <debug> Registered op exec_with_resource from plugin exec
+2026.04.29-14:45:52.60 - <debug> Loaded plugin exec from libvaccel-exec.so
+2026.04.29-14:45:52.60 - <warn> Path does not seem to have a `<prefix>://`
+2026.04.29-14:45:52.60 - <warn> Assuming /usr/local/lib/x86_64-linux-gnu/libmytestlib.so is a local path
+2026.04.29-14:45:52.60 - <debug> Initialized resource 1
+2026.04.29-14:45:52.60 - <debug> New rundir for session 1: /run/user/0/vaccel/WHJlSC/session.1
+2026.04.29-14:45:52.60 - <debug> Initialized session 1 with plugin exec
 Initialized session with id: 1
-2025.04.15-19:37:37.77 - <debug> New rundir for resource 1: /run/user/1002/vaccel/DYBt4h/resource.1
-2025.04.15-19:37:37.77 - <debug> session:1 Registered resource 1
-2025.04.15-19:37:37.77 - <debug> New rundir for resource 2: /run/user/1002/vaccel/DYBt4h/resource.2
-2025.04.15-19:37:37.77 - <debug> Persisting file lib.so to /run/user/1002/vaccel/DYBt4h/resource.2/lib.so
-2025.04.15-19:37:37.77 - <debug> Initialized resource 2
-2025.04.15-19:37:37.77 - <debug> session:1 Registered resource 2
-2025.04.15-19:37:37.77 - <debug> session:1 Looking for plugin implementing exec with resource
-2025.04.15-19:37:37.77 - <debug> Returning func from hint plugin exec
-2025.04.15-19:37:37.77 - <debug> Found implementation in exec plugin
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] session:1 Calling exec_with_resource
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] Number of libraries: 1
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] Library: /usr/local/lib/x86_64-linux-gnu/libmytestlib.so
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] Symbol: mytestfunc
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] read[0].size: 4
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] read[0].argtype: 42
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] write[0].size: 4
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] write[0].argtype: 42
+2026.04.29-14:45:52.60 - <debug> New rundir for resource 1: /run/user/0/vaccel/WHJlSC/resource.1
+2026.04.29-14:45:52.60 - <debug> session:1 Registered resource 1
+2026.04.29-14:45:52.60 - <debug> New rundir for resource 2: /run/user/0/vaccel/WHJlSC/resource.2
+2026.04.29-14:45:52.60 - <debug> Persisting file lib.so to /run/user/0/vaccel/WHJlSC/resource.2/lib.so
+2026.04.29-14:45:52.60 - <debug> Initialized resource 2
+2026.04.29-14:45:52.60 - <debug> session:1 Registered resource 2
+2026.04.29-14:45:52.60 - <debug> session:1 Looking for func implementing op exec_with_resource
+2026.04.29-14:45:52.60 - <debug> Returning func for op exec_with_resource from plugin exec
+2026.04.29-14:45:52.60 - <debug> [exec] session:1 Calling exec_with_resource
+2026.04.29-14:45:52.60 - <debug> [exec] Number of libraries: 1
+2026.04.29-14:45:52.60 - <debug> [exec] Library: /usr/local/lib/x86_64-linux-gnu/libmytestlib.so
+2026.04.29-14:45:52.60 - <debug> [exec] Symbol: mytestfunc
+2026.04.29-14:45:52.60 - <debug> [exec] read[0].size: 4
+2026.04.29-14:45:52.60 - <debug> [exec] read[0].type: int32
+2026.04.29-14:45:52.60 - <debug> [exec] write[0].size: 4
+2026.04.29-14:45:52.60 - <debug> [exec] write[0].type: int32
 I got nr_in: 1, nr_out: 1
 I got input: 10
 Will return output: 20
 output1: 20
-2025.04.15-19:37:37.77 - <debug> session:1 Looking for plugin implementing exec with resource
-2025.04.15-19:37:37.77 - <debug> Returning func from hint plugin exec
-2025.04.15-19:37:37.77 - <debug> Found implementation in exec plugin
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] session:1 Calling exec_with_resource
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] Number of libraries: 1
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] Library: /run/user/1002/vaccel/DYBt4h/resource.2/lib.so
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] Symbol: mytestfunc
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] read[0].size: 4
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] read[0].argtype: 0
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] write[0].size: 4
-2025.04.15-19:37:37.77 - <debug> [exec_with_resource] write[0].argtype: 0
+2026.04.29-14:45:52.60 - <debug> session:1 Looking for func implementing op exec_with_resource
+2026.04.29-14:45:52.60 - <debug> Returning func for op exec_with_resource from plugin exec
+2026.04.29-14:45:52.60 - <debug> [exec] session:1 Calling exec_with_resource
+2026.04.29-14:45:52.60 - <debug> [exec] Number of libraries: 1
+2026.04.29-14:45:52.60 - <debug> [exec] Library: /run/user/0/vaccel/WHJlSC/resource.2/lib.so
+2026.04.29-14:45:52.60 - <debug> [exec] Symbol: mytestfunc
+2026.04.29-14:45:52.60 - <debug> [exec] read[0].size: 4
+2026.04.29-14:45:52.60 - <debug> [exec] read[0].type: int32
+2026.04.29-14:45:52.60 - <debug> [exec] write[0].size: 4
+2026.04.29-14:45:52.60 - <debug> [exec] write[0].type: int32
 I got nr_in: 1, nr_out: 1
 I got input: 10
 Will return output: 20
 output2: 20
-2025.04.15-19:37:37.77 - <debug> session:1 Unregistered resource 2
-2025.04.15-19:37:37.77 - <debug> Removing file /run/user/1002/vaccel/DYBt4h/resource.2/lib.so
-2025.04.15-19:37:37.77 - <debug> Released resource 2
-2025.04.15-19:37:37.77 - <debug> session:1 Unregistered resource 1
-2025.04.15-19:37:37.77 - <debug> Released session 1
-2025.04.15-19:37:37.77 - <debug> Released resource 1
-2025.04.15-19:37:37.77 - <debug> Cleaning up vAccel
-2025.04.15-19:37:37.77 - <debug> Cleaning up sessions
-2025.04.15-19:37:37.77 - <debug> Cleaning up resources
-2025.04.15-19:37:37.77 - <debug> Cleaning up plugins
-2025.04.15-19:37:37.77 - <debug> Unregistered plugin exec
+2026.04.29-14:45:52.60 - <debug> session:1 Unregistered resource 2
+2026.04.29-14:45:52.60 - <debug> Removing file /run/user/0/vaccel/WHJlSC/resource.2/lib.so
+2026.04.29-14:45:52.60 - <debug> Released resource 2
+2026.04.29-14:45:52.60 - <debug> session:1 Unregistered resource 1
+2026.04.29-14:45:52.60 - <debug> Released session 1
+2026.04.29-14:45:52.60 - <debug> Released resource 1
+2026.04.29-14:45:52.60 - <debug> Cleaning up vAccel
+2026.04.29-14:45:52.60 - <debug> Cleaning up sessions
+2026.04.29-14:45:52.60 - <debug> Cleaning up resources
+2026.04.29-14:45:52.60 - <debug> Cleaning up plugins
+2026.04.29-14:45:52.60 - <debug> Unregistered plugin exec
 ```

--- a/docs/plugins/available-plugins/bundled-plugins/mbench-plugin.md
+++ b/docs/plugins/available-plugins/bundled-plugins/mbench-plugin.md
@@ -46,39 +46,37 @@ Assuming vAccel is installed at `/usr/local`, you can run an example to simulate
 
 ```console
 $ mbench 10 /usr/local/share/vaccel/images/example.jpg
-2025.04.15-19:55:11.29 - <debug> Initializing vAccel
-2025.04.15-19:55:11.29 - <info> vAccel 0.6.1-194-19056528
-2025.04.15-19:55:11.29 - <debug> Config:
-2025.04.15-19:55:11.29 - <debug>   plugins = libvaccel-mbench.so
-2025.04.15-19:55:11.29 - <debug>   log_level = debug
-2025.04.15-19:55:11.29 - <debug>   log_file = (null)
-2025.04.15-19:55:11.29 - <debug>   profiling_enabled = true
-2025.04.15-19:55:11.29 - <debug>   version_ignore = false
-2025.04.15-19:55:11.29 - <debug> Created top-level rundir: /run/user/1002/vaccel/19PFGM
-2025.04.15-19:55:11.29 - <info> Registered plugin mbench 0.6.1-194-19056528
-2025.04.15-19:55:11.29 - <debug> Registered op exec from plugin mbench
-2025.04.15-19:55:11.29 - <debug> Loaded plugin mbench from libvaccel-mbench.so
-2025.04.15-19:55:11.29 - <debug> New rundir for session 1: /run/user/1002/vaccel/19PFGM/session.1
-2025.04.15-19:55:11.29 - <debug> Initialized session 1
+2026.04.29-14:47:14.89 - <debug> Initializing vAccel
+2026.04.29-14:47:14.89 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-14:47:14.89 - <debug> Config:
+2026.04.29-14:47:14.89 - <debug>   plugins = libvaccel-mbench.so
+2026.04.29-14:47:14.89 - <debug>   log_level = debug
+2026.04.29-14:47:14.89 - <debug>   log_file = (null)
+2026.04.29-14:47:14.89 - <debug>   profiling_enabled = true
+2026.04.29-14:47:14.89 - <debug>   version_ignore = false
+2026.04.29-14:47:14.89 - <debug> Created top-level rundir: /run/user/0/vaccel/FTqcMb
+2026.04.29-14:47:14.89 - <info> Registered plugin mbench 0.7.1-93-ebc23b1f
+2026.04.29-14:47:14.89 - <debug> Registered op exec from plugin mbench
+2026.04.29-14:47:14.89 - <debug> Loaded plugin mbench from libvaccel-mbench.so
+2026.04.29-14:47:14.89 - <debug> New rundir for session 1: /run/user/0/vaccel/FTqcMb/session.1
+2026.04.29-14:47:14.89 - <debug> Initialized session 1 with plugin mbench
 Initialized session with id: 1
-2025.04.15-19:55:11.29 - <debug> Start profiling region mbench
-2025.04.15-19:55:11.29 - <debug> session:1 Looking for plugin implementing exec
-2025.04.15-19:55:11.29 - <debug> Start profiling region vaccel_exec_op
-2025.04.15-19:55:11.29 - <debug> Returning func from hint plugin mbench
-2025.04.15-19:55:11.29 - <debug> Found implementation in mbench plugin
-2025.04.15-19:55:11.29 - <debug> Calling mbench for session 1
-2025.04.15-19:55:11.29 - <debug> Start profiling region vaccel_mbench_plugin
-2025.04.15-19:55:11.30 - <debug> [mbench] 10 ms elapsed
-2025.04.15-19:55:11.30 - <debug> Stop profiling region vaccel_mbench_plugin
-2025.04.15-19:55:11.30 - <debug> Stop profiling region vaccel_exec_op
-2025.04.15-19:55:11.30 - <debug> Stop profiling region mbench
-2025.04.15-19:55:11.30 - <debug> Released session 1
-2025.04.15-19:55:11.30 - <info> [prof] mbench: total_time: 10060333 nsec nr_entries: 1
-2025.04.15-19:55:11.30 - <info> [prof] vaccel_exec_op: total_time: 10040877 nsec nr_entries: 1
-2025.04.15-19:55:11.30 - <debug> Cleaning up vAccel
-2025.04.15-19:55:11.30 - <debug> Cleaning up sessions
-2025.04.15-19:55:11.30 - <debug> Cleaning up resources
-2025.04.15-19:55:11.30 - <debug> Cleaning up plugins
-2025.04.15-19:55:11.30 - <info> [prof] vaccel_mbench_plugin: total_time: 10010329 nsec nr_entries: 1
-2025.04.15-19:55:11.30 - <debug> Unregistered plugin mbench
+2026.04.29-14:47:14.89 - <debug> Start profiling region mbench
+2026.04.29-14:47:14.89 - <debug> session:1 Looking for func implementing op exec
+2026.04.29-14:47:14.89 - <debug> Start profiling region vaccel_exec_op
+2026.04.29-14:47:14.89 - <debug> Returning func for op exec from plugin mbench
+2026.04.29-14:47:14.89 - <debug> Calling mbench for session 1
+2026.04.29-14:47:14.89 - <debug> Start profiling region vaccel_mbench_plugin
+2026.04.29-14:47:14.90 - <debug> [mbench] 10 ms elapsed
+2026.04.29-14:47:14.90 - <debug> Stop profiling region vaccel_mbench_plugin
+2026.04.29-14:47:14.90 - <debug> Stop profiling region vaccel_exec_op
+2026.04.29-14:47:14.90 - <debug> Stop profiling region mbench
+2026.04.29-14:47:14.90 - <debug> Released session 1
+2026.04.29-14:47:14.90 - <info> [prof] mbench: total_time: 10026978 nsec nr_entries: 1
+2026.04.29-14:47:14.90 - <debug> Cleaning up vAccel
+2026.04.29-14:47:14.90 - <debug> Cleaning up sessions
+2026.04.29-14:47:14.90 - <debug> Cleaning up resources
+2026.04.29-14:47:14.90 - <debug> Cleaning up plugins
+2026.04.29-14:47:14.90 - <info> [prof] vaccel_mbench_plugin: total_time: 10008901 nsec nr_entries: 1
+2026.04.29-14:47:14.90 - <debug> Unregistered plugin mbench
 ```

--- a/docs/plugins/available-plugins/bundled-plugins/noop-plugin.md
+++ b/docs/plugins/available-plugins/bundled-plugins/noop-plugin.md
@@ -67,60 +67,60 @@ classification with:
 
 ```console
 $ classify /usr/local/share/vaccel/images/example.jpg
-2025.04.03-15:44:04.61 - <debug> Initializing vAccel
-2025.04.03-15:44:04.61 - <info> vAccel 0.6.1-194-19056528
-2025.04.03-15:44:04.61 - <debug> Config:
-2025.04.03-15:44:04.61 - <debug>   plugins = libvaccel-noop.so
-2025.04.03-15:44:04.61 - <debug>   log_level = debug
-2025.04.03-15:44:04.61 - <debug>   log_file = (null)
-2025.04.03-15:44:04.61 - <debug>   profiling_enabled = false
-2025.04.03-15:44:04.61 - <debug>   version_ignore = false
-2025.04.03-15:44:04.61 - <debug> Created top-level rundir: /run/user/1002/vaccel/VC0Gxz
-2025.04.03-15:44:04.61 - <info> Registered plugin noop 0.6.1-194-19056528
-2025.04.03-15:44:04.61 - <debug> Registered op noop from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op blas_sgemm from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op image_classify from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op image_detect from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op image_segment from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op image_pose from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op image_depth from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op exec from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tf_session_load from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tf_session_run from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tf_session_delete from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op minmax from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op fpga_arraycopy from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op fpga_vectoradd from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op fpga_parallel from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op fpga_mmult from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op exec_with_resource from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op torch_jitload_forward from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op torch_sgemm from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op opencv from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tflite_session_load from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tflite_session_run from plugin noop
-2025.04.03-15:44:04.61 - <debug> Registered op tflite_session_delete from plugin noop
-2025.04.03-15:44:04.61 - <debug> Loaded plugin noop from libvaccel-noop.so
-2025.04.03-15:44:04.62 - <debug> New rundir for session 1: /run/user/1002/vaccel/VC0Gxz/session.1
-2025.04.03-15:44:04.62 - <debug> Initialized session 1
+2026.04.29-14:41:31.19 - <debug> Initializing vAccel
+2026.04.29-14:41:31.19 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-14:41:31.19 - <debug> Config:
+2026.04.29-14:41:31.19 - <debug>   plugins = libvaccel-noop.so
+2026.04.29-14:41:31.19 - <debug>   log_level = debug
+2026.04.29-14:41:31.19 - <debug>   log_file = (null)
+2026.04.29-14:41:31.19 - <debug>   profiling_enabled = false
+2026.04.29-14:41:31.19 - <debug>   version_ignore = false
+2026.04.29-14:41:31.19 - <debug> Created top-level rundir: /run/user/0/vaccel/9RDV1b
+2026.04.29-14:41:31.19 - <info> Registered plugin noop 0.7.1-93-ebc23b1f
+2026.04.29-14:41:31.19 - <debug> Registered op noop from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op exec from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op exec_with_resource from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op image_classify from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op image_detect from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op image_segment from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op image_pose from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op image_depth from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op tf_model_load from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op tf_model_unload from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op tf_model_run from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op tflite_model_load from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op tflite_model_unload from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op tflite_model_run from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op torch_model_load from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op torch_model_run from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op torch_sgemm from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op blas_sgemm from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op fpga_arraycopy from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op fpga_vectoradd from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op fpga_parallel from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op fpga_mmult from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op minmax from plugin noop
+2026.04.29-14:41:31.19 - <debug> Registered op opencv from plugin noop
+2026.04.29-14:41:31.19 - <debug> Loaded plugin noop from libvaccel-noop.so
+2026.04.29-14:41:31.19 - <debug> New rundir for session 1: /run/user/0/vaccel/9RDV1b/session.1
+2026.04.29-14:41:31.19 - <debug> Initialized session 1 with plugin noop
 Initialized session with id: 1
-2025.04.03-15:44:04.62 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.03-15:44:04.62 - <debug> Returning func from hint plugin noop
-2025.04.03-15:44:04.62 - <debug> Found implementation in noop plugin
-2025.04.03-15:44:04.62 - <debug> [noop] Calling Image classification for session 1
-2025.04.03-15:44:04.62 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.03-15:44:04.62 - <debug> [noop] model: (null)
-2025.04.03-15:44:04.62 - <debug> [noop] len_img: 79281
-2025.04.03-15:44:04.62 - <debug> [noop] len_out_text: 512
-2025.04.03-15:44:04.62 - <debug> [noop] len_out_imgname: 512
-2025.04.03-15:44:04.62 - <debug> [noop] will return a dummy result
-2025.04.03-15:44:04.62 - <debug> [noop] will return a dummy result
+2026.04.29-14:41:31.19 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.29-14:41:31.19 - <debug> Returning func for op image_classify from plugin noop
+2026.04.29-14:41:31.19 - <debug> [noop] Calling Image classification for session 1
+2026.04.29-14:41:31.19 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.29-14:41:31.19 - <debug> [noop] model: (null)
+2026.04.29-14:41:31.19 - <debug> [noop] len_img: 79281
+2026.04.29-14:41:31.19 - <debug> [noop] len_out_text: 512
+2026.04.29-14:41:31.19 - <debug> [noop] len_out_imgname: 512
+2026.04.29-14:41:31.19 - <debug> [noop] will return a dummy result
+2026.04.29-14:41:31.19 - <debug> [noop] will return a dummy result
 classification tags: This is a dummy classification tag!
 classification imagename: This is a dummy imgname!
-2025.04.03-15:44:04.62 - <debug> Released session 1
-2025.04.03-15:44:04.62 - <debug> Cleaning up vAccel
-2025.04.03-15:44:04.62 - <debug> Cleaning up sessions
-2025.04.03-15:44:04.62 - <debug> Cleaning up resources
-2025.04.03-15:44:04.62 - <debug> Cleaning up plugins
-2025.04.03-15:44:04.62 - <debug> Unregistered plugin noop
+2026.04.29-14:41:31.19 - <debug> Released session 1
+2026.04.29-14:41:31.19 - <debug> Cleaning up vAccel
+2026.04.29-14:41:31.19 - <debug> Cleaning up sessions
+2026.04.29-14:41:31.19 - <debug> Cleaning up resources
+2026.04.29-14:41:31.19 - <debug> Cleaning up plugins
+2026.04.29-14:41:31.19 - <debug> Unregistered plugin noop
 ```

--- a/docs/plugins/available-plugins/transport-plugins/rpc-plugin.md
+++ b/docs/plugins/available-plugins/transport-plugins/rpc-plugin.md
@@ -367,10 +367,10 @@ Start the RPC agent on the accelerator host, ie using the 'NoOp' plugin:
 $ VACCEL_BOOTSTRAP_ENABLED=0 vaccel-rpc-agent \
       -a "tcp://127.0.0.1:65500" \
       --vaccel-config "plugins=libvaccel-noop.so"
-[2025-04-11T20:05:14Z INFO  ttrpc::sync::server] server listen started
-[2025-04-11T20:05:14Z INFO  ttrpc::sync::server] server started
-[2025-04-11T20:05:14Z INFO  vaccel_rpc_agent] vAccel RPC agent started
-[2025-04-11T20:05:14Z INFO  vaccel_rpc_agent] Listening on 'tcp://127.0.0.1:65500', press Ctrl+C to exit
+[2026-04-30T12:42:24Z INFO  ttrpc::sync::server] server listen started
+[2026-04-30T12:42:24Z INFO  ttrpc::sync::server] server started
+[2026-04-30T12:42:24Z INFO  vaccel_rpc_agent] vAccel RPC agent started
+[2026-04-30T12:42:24Z INFO  vaccel_rpc_agent] Listening on 'tcp://127.0.0.1:65500', press Ctrl+C to exit
 ```
 
 On the same host, export the necessary variables for the plugin:
@@ -387,56 +387,57 @@ classification with:
 
 ```console
 $ classify /usr/local/share/vaccel/images/example.jpg
-2025.04.11-20:08:15.67 - <debug> Initializing vAccel
-2025.04.11-20:08:15.67 - <info> vAccel 0.6.1-194-19056528
-2025.04.11-20:08:15.67 - <debug> Config:
-2025.04.11-20:08:15.67 - <debug>   plugins = libvaccel-rpc.so
-2025.04.11-20:08:15.67 - <debug>   log_level = debug
-2025.04.11-20:08:15.67 - <debug>   log_file = (null)
-2025.04.11-20:08:15.67 - <debug>   profiling_enabled = false
-2025.04.11-20:08:15.67 - <debug>   version_ignore = false
-2025.04.11-20:08:15.67 - <debug> Created top-level rundir: /run/user/1002/vaccel/s0nza7
-2025.04.11-20:08:15.69 - <info> Registered plugin rpc 0.1.0-36-bbffdae6
-2025.04.11-20:08:15.69 - <debug> rpc is a VirtIO module
-2025.04.11-20:08:15.69 - <debug> Registered op blas_sgemm from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op image_classify from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op image_detect from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op image_segment from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op image_depth from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op image_pose from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op tflite_session_load from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op tflite_session_delete from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op tflite_session_run from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op minmax from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op fpga_arraycopy from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op fpga_mmult from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op fpga_vectoradd from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op fpga_parallel from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op exec from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op exec_with_resource from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op torch_jitload_forward from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op opencv from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op tf_session_load from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op tf_session_delete from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Registered op tf_session_run from plugin rpc
-2025.04.11-20:08:15.69 - <debug> Loaded plugin rpc from libvaccel-rpc.so
-2025.04.11-20:08:15.70 - <debug> [rpc] Initializing new remote session
-2025.04.11-20:08:15.70 - <debug> [rpc] Initialized remote session 3
-2025.04.11-20:08:15.70 - <debug> New rundir for session 1: /run/user/1002/vaccel/s0nza7/session.1
-2025.04.11-20:08:15.70 - <debug> Initialized session 1 with remote (id: 3)
+2026.04.30-12:42:37.76 - <debug> Initializing vAccel
+2026.04.30-12:42:37.76 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.30-12:42:37.76 - <debug> Config:
+2026.04.30-12:42:37.76 - <debug>   plugins = libvaccel-rpc.so
+2026.04.30-12:42:37.76 - <debug>   log_level = debug
+2026.04.30-12:42:37.76 - <debug>   log_file = (null)
+2026.04.30-12:42:37.76 - <debug>   profiling_enabled = false
+2026.04.30-12:42:37.76 - <debug>   version_ignore = false
+2026.04.30-12:42:37.78 - <debug> Created top-level rundir: /run/user/0/vaccel/zha8un
+2026.04.30-12:42:37.78 - <info> Registered plugin rpc 0.2.1-21-e08235e7
+2026.04.30-12:42:37.78 - <debug> rpc is a VirtIO module
+2026.04.30-12:42:37.78 - <debug> Registered op exec from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op exec_with_resource from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op image_classify from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op image_detect from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op image_segment from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op image_depth from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op image_pose from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op tflite_model_load from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op tflite_model_unload from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op tflite_model_run from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op torch_model_load from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op torch_model_run from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op blas_sgemm from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op fpga_arraycopy from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op fpga_mmult from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op fpga_parallel from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op fpga_vectoradd from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op minmax from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op opencv from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op tf_model_load from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op tf_model_unload from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Registered op tf_model_run from plugin rpc
+2026.04.30-12:42:37.78 - <debug> Loaded plugin rpc from libvaccel-rpc.so
+2026.04.30-12:42:37.79 - <debug> [rpc] Initializing new remote session
+2026.04.30-12:42:37.79 - <debug> [rpc] Initialized remote session 1
+2026.04.30-12:42:37.79 - <debug> New rundir for session 1: /run/user/0/vaccel/zha8un/session.1
+2026.04.30-12:42:37.79 - <debug> Initialized session 1 with plugin rpc (remote id: 1)
 Initialized session with id: 1
-2025.04.11-20:08:15.70 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.11-20:08:15.70 - <debug> Returning func from hint plugin rpc
-2025.04.11-20:08:15.70 - <debug> Found implementation in rpc plugin
+2026.04.30-12:42:37.79 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.30-12:42:37.79 - <debug> Returning func for op image_classify from plugin rpc
+2026.04.30-12:42:37.79 - <debug> [rpc] session:1 Executing op image_classify
 classification tags: This is a dummy classification tag!
 classification imagename: This is a dummy imgname!
-2025.04.11-20:08:15.75 - <debug> [rpc] Releasing remote session 3
-2025.04.11-20:08:15.83 - <debug> Released session 1
-2025.04.11-20:08:15.83 - <debug> Cleaning up vAccel
-2025.04.11-20:08:15.83 - <debug> Cleaning up sessions
-2025.04.11-20:08:15.83 - <debug> Cleaning up resources
-2025.04.11-20:08:15.83 - <debug> Cleaning up plugins
-2025.04.11-20:08:15.83 - <debug> Unregistered plugin rpc
+2026.04.30-12:42:37.83 - <debug> [rpc] Releasing remote session 1
+2026.04.30-12:42:37.91 - <debug> Released session 1
+2026.04.30-12:42:37.91 - <debug> Cleaning up vAccel
+2026.04.30-12:42:37.91 - <debug> Cleaning up sessions
+2026.04.30-12:42:37.91 - <debug> Cleaning up resources
+2026.04.30-12:42:37.91 - <debug> Cleaning up plugins
+2026.04.30-12:42:37.91 - <debug> Unregistered plugin rpc
 ```
 
 <!-- markdownlint-disable code-block-style -->

--- a/docs/plugins/available-plugins/transport-plugins/virtio-plugin.md
+++ b/docs/plugins/available-plugins/transport-plugins/virtio-plugin.md
@@ -342,63 +342,63 @@ $ docker run --rm --device=/dev/kvm -it \
       harbor.nbfc.io/nubificus/qemu-vaccel \
       -r rootfs.img --drive-cache -k bzImage* \
       -M pc,accel=kvm --vcpus 2 -m 2048 \
-      -c "classify /usr/local/share/vaccel/images/example.jpg"
-2025.04.12-20:01:09.85 - <debug> Initializing vAccel
-2025.04.12-20:01:09.85 - <info> vAccel 0.6.1-194-19056528
-2025.04.12-20:01:09.85 - <debug> Config:
-2025.04.12-20:01:09.85 - <debug>   plugins = libvaccel-noop.so
-2025.04.12-20:01:09.85 - <debug>   log_level = debug
-2025.04.12-20:01:09.85 - <debug>   log_file = (null)
-2025.04.12-20:01:09.85 - <debug>   profiling_enabled = false
-2025.04.12-20:01:09.85 - <debug>   version_ignore = false
-2025.04.12-20:01:09.85 - <debug> Created top-level rundir: /run/user/0/vaccel/u05Rjf
-2025.04.12-20:01:09.85 - <info> Registered plugin noop 0.6.1-194-19056528
-2025.04.12-20:01:09.85 - <debug> Registered op noop from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op blas_sgemm from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op image_classify from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op image_detect from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op image_segment from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op image_pose from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op image_depth from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op exec from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tf_session_load from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tf_session_run from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tf_session_delete from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op minmax from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op fpga_arraycopy from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op fpga_vectoradd from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op fpga_parallel from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op fpga_mmult from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op exec_with_resource from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op torch_jitload_forward from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op torch_sgemm from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op opencv from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tflite_session_load from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tflite_session_run from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tflite_session_delete from plugin noop
-2025.04.12-20:01:09.85 - <debug> Loaded plugin noop from libvaccel-noop.so
-2025.04.12-20:01:16.73 - <debug> New rundir for session 1: /run/user/0/vaccel/u05Rjf/session.1
-2025.04.12-20:01:16.73 - <debug> Initialized session 1
-2025.04.12-20:01:16.73 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.12-20:01:16.73 - <debug> Returning func from hint plugin noop
-2025.04.12-20:01:16.73 - <debug> Found implementation in noop plugin
-2025.04.12-20:01:16.73 - <debug> [noop] Calling Image classification for session 1
-2025.04.12-20:01:16.73 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.12-20:01:16.73 - <debug> [noop] model: (null)
-2025.04.12-20:01:16.73 - <debug> [noop] len_img: 79281
-2025.04.12-20:01:16.73 - <debug> [noop] len_out_text: 512
-2025.04.12-20:01:16.73 - <debug> [noop] len_out_imgname: 512
-2025.04.12-20:01:16.73 - <debug> [noop] will return a dummy result
-2025.04.12-20:01:16.73 - <debug> [noop] will return a dummy result
-2025.04.12-20:01:16.73 - <debug> Released session 1
+      -c "classify /usr/share/vaccel/images/example.jpg"
+2026.04.30-13:00:51.21 - <debug> Initializing vAccel
+2026.04.30-13:00:51.21 - <info> vAccel 0.7.1-92-995d8f4c
+2026.04.30-13:00:51.21 - <debug> Config:
+2026.04.30-13:00:51.21 - <debug>   plugins = libvaccel-noop.so
+2026.04.30-13:00:51.21 - <debug>   log_level = debug
+2026.04.30-13:00:51.21 - <debug>   log_file = (null)
+2026.04.30-13:00:51.21 - <debug>   profiling_enabled = false
+2026.04.30-13:00:51.21 - <debug>   version_ignore = false
+2026.04.30-13:00:51.21 - <debug> Created top-level rundir: /run/user/0/vaccel/dx3GKu
+2026.04.30-13:00:51.21 - <info> Registered plugin noop 0.7.1-92-995d8f4c
+2026.04.30-13:00:51.21 - <debug> Registered op noop from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op exec from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op exec_with_resource from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op image_classify from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op image_detect from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op image_segment from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op image_pose from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op image_depth from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tf_model_load from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tf_model_unload from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tf_model_run from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tflite_model_load from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tflite_model_unload from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tflite_model_run from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op torch_model_load from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op torch_model_run from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op torch_sgemm from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op blas_sgemm from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op fpga_arraycopy from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op fpga_vectoradd from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op fpga_parallel from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op fpga_mmult from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op minmax from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op opencv from plugin noop
+2026.04.30-13:00:51.21 - <debug> Loaded plugin noop from libvaccel-noop.so
+2026.04.30-13:00:57.90 - <debug> New rundir for session 1: /run/user/0/vaccel/dx3GKu/session.1
+2026.04.30-13:00:57.90 - <debug> Initialized session 1 with plugin noop
+2026.04.30-13:00:57.90 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.30-13:00:57.90 - <debug> Returning func for op image_classify from plugin noop
+2026.04.30-13:00:57.90 - <debug> [noop] Calling Image classification for session 1
+2026.04.30-13:00:57.90 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.30-13:00:57.90 - <debug> [noop] model: (null)
+2026.04.30-13:00:57.90 - <debug> [noop] len_img: 79281
+2026.04.30-13:00:57.90 - <debug> [noop] len_out_text: 512
+2026.04.30-13:00:57.90 - <debug> [noop] len_out_imgname: 512
+2026.04.30-13:00:57.90 - <debug> [noop] will return a dummy result
+2026.04.30-13:00:57.90 - <debug> [noop] will return a dummy result
+2026.04.30-13:00:57.90 - <debug> Released session 1
 Initialized session with id: 1
 classification tags: This is a dummy classification tag!
 classification imagename: This is a dummy imgname!
-2025.04.12-20:01:17.06 - <debug> Cleaning up vAccel
-2025.04.12-20:01:17.06 - <debug> Cleaning up sessions
-2025.04.12-20:01:17.06 - <debug> Cleaning up resources
-2025.04.12-20:01:17.06 - <debug> Cleaning up plugins
-2025.04.12-20:01:17.06 - <debug> Unregistered plugin noop
+2026.04.30-13:00:58.32 - <debug> Cleaning up vAccel
+2026.04.30-13:00:58.32 - <debug> Cleaning up sessions
+2026.04.30-13:00:58.32 - <debug> Cleaning up resources
+2026.04.30-13:00:58.32 - <debug> Cleaning up plugins
+2026.04.30-13:00:58.32 - <debug> Unregistered plugin noop
 ```
 
 ///
@@ -413,61 +413,61 @@ $ docker run --rm --device=/dev/kvm -it \
       -r rootfs.img --drive-cache -k Image* \
       --cmdline-append "console=ttyAMA0,115200" \
       -M virt --no-pci --vcpus 2 -m 2048 \
-      -c "classify /usr/local/share/vaccel/images/example.jpg"
-2025.04.12-20:01:09.85 - <debug> Initializing vAccel
-2025.04.12-20:01:09.85 - <info> vAccel 0.6.1-194-19056528
-2025.04.12-20:01:09.85 - <debug> Config:
-2025.04.12-20:01:09.85 - <debug>   plugins = libvaccel-noop.so
-2025.04.12-20:01:09.85 - <debug>   log_level = debug
-2025.04.12-20:01:09.85 - <debug>   log_file = (null)
-2025.04.12-20:01:09.85 - <debug>   profiling_enabled = false
-2025.04.12-20:01:09.85 - <debug>   version_ignore = false
-2025.04.12-20:01:09.85 - <debug> Created top-level rundir: /run/user/0/vaccel/u05Rjf
-2025.04.12-20:01:09.85 - <info> Registered plugin noop 0.6.1-194-19056528
-2025.04.12-20:01:09.85 - <debug> Registered op noop from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op blas_sgemm from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op image_classify from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op image_detect from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op image_segment from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op image_pose from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op image_depth from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op exec from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tf_session_load from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tf_session_run from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tf_session_delete from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op minmax from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op fpga_arraycopy from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op fpga_vectoradd from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op fpga_parallel from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op fpga_mmult from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op exec_with_resource from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op torch_jitload_forward from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op torch_sgemm from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op opencv from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tflite_session_load from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tflite_session_run from plugin noop
-2025.04.12-20:01:09.85 - <debug> Registered op tflite_session_delete from plugin noop
-2025.04.12-20:01:09.85 - <debug> Loaded plugin noop from libvaccel-noop.so
-2025.04.12-20:01:16.73 - <debug> New rundir for session 1: /run/user/0/vaccel/u05Rjf/session.1
-2025.04.12-20:01:16.73 - <debug> Initialized session 1
-2025.04.12-20:01:16.73 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.12-20:01:16.73 - <debug> Returning func from hint plugin noop
-2025.04.12-20:01:16.73 - <debug> Found implementation in noop plugin
-2025.04.12-20:01:16.73 - <debug> [noop] Calling Image classification for session 1
-2025.04.12-20:01:16.73 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.12-20:01:16.73 - <debug> [noop] model: (null)
-2025.04.12-20:01:16.73 - <debug> [noop] len_img: 79281
-2025.04.12-20:01:16.73 - <debug> [noop] len_out_text: 512
-2025.04.12-20:01:16.73 - <debug> [noop] len_out_imgname: 512
-2025.04.12-20:01:16.73 - <debug> [noop] will return a dummy result
-2025.04.12-20:01:16.73 - <debug> [noop] will return a dummy result
-2025.04.12-20:01:16.73 - <debug> Released session 1
+      -c "classify /usr/share/vaccel/images/example.jpg"
+2026.04.30-13:00:51.21 - <debug> Initializing vAccel
+2026.04.30-13:00:51.21 - <info> vAccel 0.7.1-92-995d8f4c
+2026.04.30-13:00:51.21 - <debug> Config:
+2026.04.30-13:00:51.21 - <debug>   plugins = libvaccel-noop.so
+2026.04.30-13:00:51.21 - <debug>   log_level = debug
+2026.04.30-13:00:51.21 - <debug>   log_file = (null)
+2026.04.30-13:00:51.21 - <debug>   profiling_enabled = false
+2026.04.30-13:00:51.21 - <debug>   version_ignore = false
+2026.04.30-13:00:51.21 - <debug> Created top-level rundir: /run/user/0/vaccel/dx3GKu
+2026.04.30-13:00:51.21 - <info> Registered plugin noop 0.7.1-92-995d8f4c
+2026.04.30-13:00:51.21 - <debug> Registered op noop from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op exec from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op exec_with_resource from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op image_classify from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op image_detect from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op image_segment from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op image_pose from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op image_depth from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tf_model_load from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tf_model_unload from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tf_model_run from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tflite_model_load from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tflite_model_unload from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op tflite_model_run from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op torch_model_load from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op torch_model_run from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op torch_sgemm from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op blas_sgemm from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op fpga_arraycopy from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op fpga_vectoradd from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op fpga_parallel from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op fpga_mmult from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op minmax from plugin noop
+2026.04.30-13:00:51.21 - <debug> Registered op opencv from plugin noop
+2026.04.30-13:00:51.21 - <debug> Loaded plugin noop from libvaccel-noop.so
+2026.04.30-13:00:57.90 - <debug> New rundir for session 1: /run/user/0/vaccel/dx3GKu/session.1
+2026.04.30-13:00:57.90 - <debug> Initialized session 1 with plugin noop
+2026.04.30-13:00:57.90 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.30-13:00:57.90 - <debug> Returning func for op image_classify from plugin noop
+2026.04.30-13:00:57.90 - <debug> [noop] Calling Image classification for session 1
+2026.04.30-13:00:57.90 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.30-13:00:57.90 - <debug> [noop] model: (null)
+2026.04.30-13:00:57.90 - <debug> [noop] len_img: 79281
+2026.04.30-13:00:57.90 - <debug> [noop] len_out_text: 512
+2026.04.30-13:00:57.90 - <debug> [noop] len_out_imgname: 512
+2026.04.30-13:00:57.90 - <debug> [noop] will return a dummy result
+2026.04.30-13:00:57.90 - <debug> [noop] will return a dummy result
+2026.04.30-13:00:57.90 - <debug> Released session 1
 Initialized session with id: 1
 classification tags: This is a dummy classification tag!
 classification imagename: This is a dummy imgname!
-2025.04.12-20:01:17.06 - <debug> Cleaning up vAccel
-2025.04.12-20:01:17.06 - <debug> Cleaning up sessions
-2025.04.12-20:01:17.06 - <debug> Cleaning up resources
-2025.04.12-20:01:17.06 - <debug> Cleaning up plugins
-2025.04.12-20:01:17.06 - <debug> Unregistered plugin noop
+2026.04.30-13:00:58.32 - <debug> Cleaning up vAccel
+2026.04.30-13:00:58.32 - <debug> Cleaning up sessions
+2026.04.30-13:00:58.32 - <debug> Cleaning up resources
+2026.04.30-13:00:58.32 - <debug> Cleaning up plugins
+2026.04.30-13:00:58.32 - <debug> Unregistered plugin noop
 ```

--- a/docs/plugins/available-plugins/transport-plugins/virtio-plugin.md
+++ b/docs/plugins/available-plugins/transport-plugins/virtio-plugin.md
@@ -39,6 +39,9 @@ implementation of the virtio-accel backend.
 - [Exec](../../../api/api-reference/operations.md#exec)
 - [Exec with resource](../../../api/api-reference/operations.md#exec-with-resource)
 
+- [Torch model load](../../../api/api-reference/operations.md#torch-model-load)
+- [Torch model run](../../../api/api-reference/operations.md#torch-model-run)
+
 - [MinMax](../../../api/api-reference/operations.md#minmax)
 - [Generic operation](../../../api/api-reference/operations.md#generic-operation)
 - [Debug operation](../../../api/api-reference/operations.md#debug-operation)

--- a/docs/tutorials/deploying-vaccel-applications-using-kubernetes.md
+++ b/docs/tutorials/deploying-vaccel-applications-using-kubernetes.md
@@ -113,29 +113,29 @@ Agent logs, before the client start:
 
 ```console
 $ kubectl logs vaccel-sidecar-pod -c vaccel-agent
-[2025-06-22T22:30:03Z INFO  ttrpc::sync::server] server listen started
-[2025-06-22T22:30:03Z INFO  ttrpc::sync::server] server started
-[2025-06-22T22:30:03Z INFO  vaccel_rpc_agent] vAccel RPC agent started
-[2025-06-22T22:30:03Z INFO  vaccel_rpc_agent] Listening on 'unix:///var/run/vaccel/vaccel.sock', press Ctrl+C to exit
+[2026-04-30T14:52:39Z INFO  ttrpc::sync::server] server listen started
+[2026-04-30T14:52:39Z INFO  ttrpc::sync::server] server started
+[2026-04-30T14:52:39Z INFO  vaccel_rpc_agent] vAccel RPC agent started
+[2026-04-30T14:52:39Z INFO  vaccel_rpc_agent] Listening on 'unix:///var/run/vaccel/vaccel.sock', press Ctrl+C to exit
 ```
 
 Client logs:
 
 ```console
 $ kubectl logs vaccel-sidecar-pod -c vaccel-client
-2025.06.22-22:30:03.73 - <info> vAccel 0.7.0-7-e67e52b6
-2025.06.22-22:30:03.73 - <info> Registered plugin rpc 0.2.0-1-eca9e440
+2026.04.30-14:57:33.00 - <info> vAccel 0.7.1-25-8aea5ec0
+2026.04.30-14:57:33.00 - <info> Registered plugin rpc 0.2.1-7-925667dc
 Processing 26954 lines from: /data/tweets.txt
 == [Vocab Loaded] ==
-2025.06.22-22:30:03.78 - <warn> Path does not seem to have a `<prefix>://`
-2025.06.22-22:30:03.78 - <warn> Assuming cnn_trace.pt is a local path
-vaccel_resource_new(): Time Taken: 68500 nanoseconds
+2026.04.30-14:57:33.03 - <warn> Path does not seem to have a `<prefix>://`
+2026.04.30-14:57:33.03 - <warn> Assuming cnn_trace.pt is a local path
+vaccel_resource_new(): Time Taken: 49075 nanoseconds
 Created new model resource 1
 Initialized vAccel session 1
-Line 1: Duration: 497.627 ms Prediction: neither
-Line 2: Duration: 198.996 ms Prediction: offensive-language
-Line 3: Duration: 359.865 ms Prediction: offensive-language
-Line 4: Duration: 69.7109 ms Prediction: offensive-language
+Line 1: Duration: 101.775 ms Prediction: neither
+Line 2: Duration: 126.993 ms Prediction: offensive-language
+Line 3: Duration: 204.097 ms Prediction: offensive-language
+Line 4: Duration: 63.1958 ms Prediction: offensive-language
 ...
 ```
 
@@ -143,16 +143,16 @@ Agent logs, after client initial connection:
 
 ```console
 $ kubectl logs vaccel-sidecar-pod -c vaccel-agent
-[2025-06-22T22:30:03Z INFO  ttrpc::sync::server] server listen started
-[2025-06-22T22:30:03Z INFO  ttrpc::sync::server] server started
-[2025-06-22T22:30:03Z INFO  vaccel_rpc_agent] vAccel RPC agent started
-[2025-06-22T22:30:03Z INFO  vaccel_rpc_agent] Listening on 'unix:///var/run/vaccel/vaccel.sock', press Ctrl+C to exit
-[2025-06-22T22:30:03Z INFO  vaccel_rpc_agent::session] Created session 1
-[2025-06-22T22:30:05Z INFO  vaccel_rpc_agent::resource] Creating new resource
-[2025-06-22T22:30:05Z INFO  vaccel_rpc_agent::resource] Registering resource 1 with session 1
-[2025-06-22T22:30:06Z INFO  vaccel_rpc_agent::ops::torch] session:1 PyTorch jitload forward
-[2025-06-22T22:30:06Z INFO  vaccel_rpc_agent::ops::torch] session:1 PyTorch jitload forward
-[2025-06-22T22:30:06Z INFO  vaccel_rpc_agent::ops::torch] session:1 PyTorch jitload forward
+[2026-04-30T14:52:39Z INFO  ttrpc::sync::server] server listen started
+[2026-04-30T14:52:39Z INFO  ttrpc::sync::server] server started
+[2026-04-30T14:52:39Z INFO  vaccel_rpc_agent] vAccel RPC agent started
+[2026-04-30T14:52:39Z INFO  vaccel_rpc_agent] Listening on 'unix:///var/run/vaccel/vaccel.sock', press Ctrl+C to exit
+[2026-04-30T14:57:33Z INFO  vaccel_rpc_agent::session] Created session 1
+[2026-04-30T14:57:34Z INFO  vaccel_rpc_agent::resource] Creating new resource
+[2026-04-30T14:57:34Z INFO  vaccel_rpc_agent::resource] Registering resource 1 with session 1
+[2026-04-30T14:57:34Z INFO  vaccel_rpc_agent::ops::torch] session:1 PyTorch load model
+[2026-04-30T14:57:36Z INFO  vaccel_rpc_agent::ops::torch] session:1 PyTorch model run
+[2026-04-30T14:57:36Z INFO  vaccel_rpc_agent::ops::torch] session:1 PyTorch model run
 ...
 ```
 
@@ -247,19 +247,19 @@ $ kubectl apply -f daemonset-agent.yaml
 daemonset.apps/vaccel-agent created
 service/vaccel-agent created
 $ kubectl get pods -o wide
-NAME                             READY   STATUS         RESTARTS       AGE    IP              NODE      NOMINATED NODE   READINESS GATES
-vaccel-agent-p4zxg               1/1     Running        0              15s    10.244.43.21    node1     <none>           <none>
-$ kubectl logs vaccel-agent-p4zxg
-[2025-06-22T22:34:34Z INFO  ttrpc::sync::server] server listen started
-[2025-06-22T22:34:34Z INFO  ttrpc::sync::server] server started
-[2025-06-22T22:34:34Z INFO  vaccel_rpc_agent] vAccel RPC agent started
-[2025-06-22T22:34:34Z INFO  vaccel_rpc_agent] Listening on 'tcp://0.0.0.0:8888', press Ctrl+C to exit
+NAME                             READY   STATUS         RESTARTS       AGE    IP              NODE         NOMINATED NODE   READINESS GATES
+vaccel-agent-cgjmr               1/1     Running        0              15s    10.42.0.10      vaccel-k8s   <none>           <none>
+$ kubectl logs vaccel-agent-cgjmr
+[2026-04-30T15:01:10Z INFO  ttrpc::sync::server] server listen started
+[2026-04-30T15:01:10Z INFO  ttrpc::sync::server] server started
+[2026-04-30T15:01:10Z INFO  vaccel_rpc_agent] vAccel RPC agent started
+[2026-04-30T15:01:10Z INFO  vaccel_rpc_agent] Listening on 'tcp://0.0.0.0:8888', press Ctrl+C to exit
 ```
 
 ```console
 $ kubectl get svc -o wide
-NAME               TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE    SELECTOR
-vaccel-agent       ClusterIP   10.244.21.70   <none>        8888/TCP   64s    app=vaccel-agent
+NAME               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE     SELECTOR
+vaccel-agent       ClusterIP   10.43.148.202   <none>        8888/TCP   2m13s   app=vaccel-agent
 ```
 
 Client spawn:
@@ -268,24 +268,24 @@ Client spawn:
 $ kubectl apply -f client.yaml
 pod/vaccel-client created
 $ kubectl get pods -o wide
-NAME                             READY   STATUS             RESTARTS       AGE    IP              NODE      NOMINATED NODE   READINESS GATES
-vaccel-agent-p4zxg               1/1     Running            0              2m9s   10.244.43.21    node1     <none>           <none>
-vaccel-client                    1/1     Running            0              11s    10.244.43.1     node1     <none>           <none>
+NAME                             READY   STATUS             RESTARTS       AGE     IP              NODE         NOMINATED NODE   READINESS GATES
+vaccel-agent-cgjmr               1/1     Running            0              3m35s   10.42.0.10      vaccel-k8s   <none>           <none>
+vaccel-client                    1/1     Running            0              82s     10.42.0.11      vaccel-k8s   <none>           <none>
 $ kubectl logs vaccel-client
-2025.06.22-22:36:32.01 - <info> vAccel 0.7.0-7-e67e52b6
-2025.06.22-22:36:32.02 - <info> Registered plugin rpc 0.2.0-1-eca9e440
+2026.04.30-15:01:43.45 - <info> vAccel 0.7.1-25-8aea5ec0
+2026.04.30-15:01:43.45 - <info> Registered plugin rpc 0.2.1-7-925667dc
 Processing 26954 lines from: /data/tweets.txt
 == [Vocab Loaded] ==
-2025.06.22-22:36:32.07 - <warn> Path does not seem to have a `<prefix>://`
-2025.06.22-22:36:32.07 - <warn> Assuming cnn_trace.pt is a local path
-vaccel_resource_new(): Time Taken: 67057 nanoseconds
+2026.04.30-15:01:43.48 - <warn> Path does not seem to have a `<prefix>://`
+2026.04.30-15:01:43.48 - <warn> Assuming cnn_trace.pt is a local path
+vaccel_resource_new(): Time Taken: 46303 nanoseconds
 Created new model resource 1
 Initialized vAccel session 1
-Line 1: Duration: 551.823 ms Prediction: neither
-Line 2: Duration: 279.833 ms Prediction: offensive-language
-Line 3: Duration: 413.417 ms Prediction: offensive-language
-Line 4: Duration: 120.675 ms Prediction: offensive-language
-Line 5: Duration: 185.506 ms Prediction: neither
+Line 1: Duration: 98.7296 ms Prediction: neither
+Line 2: Duration: 186.415 ms Prediction: offensive-language
+Line 3: Duration: 236.044 ms Prediction: offensive-language
+Line 4: Duration: 87.602 ms Prediction: offensive-language
+Line 5: Duration: 111.111 ms Prediction: neither
 ...
 ```
 

--- a/docs/tutorials/running-a-vaccel-application-on-a-vm.md
+++ b/docs/tutorials/running-a-vaccel-application-on-a-vm.md
@@ -500,19 +500,35 @@ applicable law.
 root@localhost:~#
 ```
 
-You can verify all required libraries are installed by looking at
+You can verify the `RPC` plugin was installed by looking at
 `/usr/local/lib/x86_64-linux-gnu`:
 
 ```console
 # ls /usr/local/lib/x86_64-linux-gnu/
-libmytestlib.so            libvaccel-noop.so.0        libvaccel-virtio.so
-libvaccel-exec.so          libvaccel-noop.so.0.6.1    libvaccel-virtio.so.0
-libvaccel-exec.so.0        libvaccel-python.so        libvaccel-virtio.so.0.1.0
-libvaccel-exec.so.0.6.1    libvaccel-python.so.0      libvaccel.so
-libvaccel-mbench.so        libvaccel-python.so.0.6.1  libvaccel.so.0
-libvaccel-mbench.so.0      libvaccel-rpc.so           libvaccel.so.0.6.1
-libvaccel-mbench.so.0.6.1  libvaccel-rpc.so.0         pkgconfig
-libvaccel-noop.so          libvaccel-rpc.so.0.1.0
+libvaccel-rpc.so  libvaccel-rpc.so.0  libvaccel-rpc.so.0.2.1  pkgconfig
+```
+
+The rest of the vAccel libraries are pre-installed in the rootfs at
+`/usr/lib/x86_64-linux-gnu`:
+
+```console
+# ls /usr/lib/x86_64-linux-gnu/ | grep -E 'libvaccel|libmytestlib' | sort
+libmytestlib.so
+libvaccel-exec.so
+libvaccel-exec.so.0
+libvaccel-exec.so.0.7.1
+libvaccel-mbench.so
+libvaccel-mbench.so.0
+libvaccel-mbench.so.0.7.1
+libvaccel-noop.so
+libvaccel-noop.so.0
+libvaccel-noop.so.0.7.1
+libvaccel-virtio.so
+libvaccel-virtio.so.0
+libvaccel-virtio.so.0.2.0
+libvaccel.so
+libvaccel.so.0
+libvaccel.so.0.7.1
 ```
 
 ## Running the vAccel RPC agent
@@ -559,44 +575,45 @@ To start a `vaccel-rpc-agent` with the vAccel `NoOp` plugin use:
 $ VACCEL_BOOTSTRAP_ENABLED=0 vaccel-rpc-agent \
       -a "${VACCEL_RPC_ADDRESS}" \
       --vaccel-config "plugins=libvaccel-noop.so,log_level=4"
-2025.04.08-19:34:05.40 - <debug> Initializing vAccel
-2025.04.08-19:34:05.40 - <info> vAccel 0.6.1-194-19056528
-2025.04.08-19:34:05.40 - <debug> Config:
-2025.04.08-19:34:05.40 - <debug>   plugins = libvaccel-noop.so
-2025.04.08-19:34:05.40 - <debug>   log_level = debug
-2025.04.08-19:34:05.40 - <debug>   log_file = (null)
-2025.04.08-19:34:05.40 - <debug>   profiling_enabled = false
-2025.04.08-19:34:05.40 - <debug>   version_ignore = false
-2025.04.08-19:34:05.40 - <debug> Created top-level rundir: /run/user/1002/vaccel/j1Kwrv
-2025.04.08-19:34:05.40 - <info> Registered plugin noop 0.6.1-194-19056528
-2025.04.08-19:34:05.40 - <debug> Registered op noop from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op blas_sgemm from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op image_classify from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op image_detect from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op image_segment from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op image_pose from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op image_depth from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op exec from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op tf_session_load from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op tf_session_run from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op tf_session_delete from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op minmax from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op fpga_arraycopy from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op fpga_vectoradd from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op fpga_parallel from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op fpga_mmult from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op exec_with_resource from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op torch_jitload_forward from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op torch_sgemm from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op opencv from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op tflite_session_load from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op tflite_session_run from plugin noop
-2025.04.08-19:34:05.40 - <debug> Registered op tflite_session_delete from plugin noop
-2025.04.08-19:34:05.40 - <debug> Loaded plugin noop from libvaccel-noop.so
-[2025-04-08T19:34:05Z INFO  ttrpc::sync::server] server listen started
-[2025-04-08T19:34:05Z INFO  ttrpc::sync::server] server started
-[2025-04-08T19:34:05Z INFO  vaccel_rpc_agent] vAccel RPC agent started
-[2025-04-08T19:34:05Z INFO  vaccel_rpc_agent] Listening on 'vsock://2:2048', press Ctrl+C to exit
+2026.04.30-13:28:36.25 - <debug> Initializing vAccel
+2026.04.30-13:28:36.25 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.30-13:28:36.25 - <debug> Config:
+2026.04.30-13:28:36.25 - <debug>   plugins = libvaccel-noop.so
+2026.04.30-13:28:36.25 - <debug>   log_level = debug
+2026.04.30-13:28:36.25 - <debug>   log_file = (null)
+2026.04.30-13:28:36.25 - <debug>   profiling_enabled = false
+2026.04.30-13:28:36.25 - <debug>   version_ignore = false
+2026.04.30-13:28:36.28 - <debug> Created top-level rundir: /run/user/0/vaccel/yAuTYA
+2026.04.30-13:28:36.28 - <info> Registered plugin noop 0.7.1-93-ebc23b1f
+2026.04.30-13:28:36.28 - <debug> Registered op noop from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op exec from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op exec_with_resource from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op image_classify from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op image_detect from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op image_segment from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op image_pose from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op image_depth from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op tf_model_load from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op tf_model_unload from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op tf_model_run from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op tflite_model_load from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op tflite_model_unload from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op tflite_model_run from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op torch_model_load from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op torch_model_run from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op torch_sgemm from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op blas_sgemm from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op fpga_arraycopy from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op fpga_vectoradd from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op fpga_parallel from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op fpga_mmult from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op minmax from plugin noop
+2026.04.30-13:28:36.28 - <debug> Registered op opencv from plugin noop
+2026.04.30-13:28:36.28 - <debug> Loaded plugin noop from libvaccel-noop.so
+[2026-04-30T13:28:36Z INFO  ttrpc::sync::server] server listen started
+[2026-04-30T13:28:36Z INFO  ttrpc::sync::server] server started
+[2026-04-30T13:28:36Z INFO  vaccel_rpc_agent] vAccel RPC agent started
+[2026-04-30T13:28:36Z INFO  vaccel_rpc_agent] Listening on 'vsock://2:2048', press Ctrl+C to exit
 ```
 
 ## Running the application on the guest
@@ -629,80 +646,80 @@ export VACCEL_LOG_LEVEL=4
 Finally, you can run an image classification example with:
 
 ```console
-# classify /usr/local/share/vaccel/images/example.jpg 1
-2025.04.08-19:34:48.28 - <debug> Initializing vAccel
-2025.04.08-19:34:48.28 - <info> vAccel 0.6.1-194-19056528
-2025.04.08-19:34:48.28 - <debug> Config:
-2025.04.08-19:34:48.28 - <debug>   plugins = libvaccel-rpc.so
-2025.04.08-19:34:48.28 - <debug>   log_level = debug
-2025.04.08-19:34:48.28 - <debug>   log_file = (null)
-2025.04.08-19:34:48.28 - <debug>   profiling_enabled = false
-2025.04.08-19:34:48.28 - <debug>   version_ignore = false
-2025.04.08-19:34:48.28 - <debug> Created top-level rundir: /run/user/0/vaccel/JE4UiS
-2025.04.08-19:34:48.30 - <info> Registered plugin rpc 0.1.0-36-bbffdae6
-2025.04.08-19:34:48.30 - <debug> rpc is a VirtIO module
-2025.04.08-19:34:48.30 - <debug> Registered op blas_sgemm from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op image_classify from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op image_detect from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op image_segment from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op image_depth from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op image_pose from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op tflite_session_load from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op tflite_session_delete from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op tflite_session_run from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op minmax from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op fpga_arraycopy from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op fpga_mmult from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op fpga_vectoradd from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op fpga_parallel from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op exec from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op exec_with_resource from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op torch_jitload_forward from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op opencv from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op tf_session_load from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op tf_session_delete from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Registered op tf_session_run from plugin rpc
-2025.04.08-19:34:48.30 - <debug> Loaded plugin rpc from libvaccel-rpc.so
-2025.04.08-19:34:48.31 - <debug> [rpc] Initializing new remote session
-2025.04.08-19:34:48.34 - <debug> [rpc] Initialized remote session 1
-2025.04.08-19:34:48.34 - <debug> New rundir for session 1: /run/user/0/vaccel/JE4UiS/session.1
-2025.04.08-19:34:48.34 - <debug> Initialized session 1 with remote (id: 1)
+# classify /usr/share/vaccel/images/example.jpg 1
+2026.04.30-13:28:58.56 - <debug> Initializing vAccel
+2026.04.30-13:28:58.57 - <info> vAccel 0.7.1-92-995d8f4c
+2026.04.30-13:28:58.57 - <debug> Config:
+2026.04.30-13:28:58.57 - <debug>   plugins = libvaccel-rpc.so
+2026.04.30-13:28:58.57 - <debug>   log_level = debug
+2026.04.30-13:28:58.57 - <debug>   log_file = (null)
+2026.04.30-13:28:58.57 - <debug>   profiling_enabled = false
+2026.04.30-13:28:58.57 - <debug>   version_ignore = false
+2026.04.30-13:28:58.58 - <debug> Created top-level rundir: /run/user/0/vaccel/6dyxAu
+2026.04.30-13:28:58.59 - <info> Registered plugin rpc 0.2.1-14-9ae931a0
+2026.04.30-13:28:58.59 - <debug> rpc is a VirtIO module
+2026.04.30-13:28:58.59 - <debug> Registered op exec from plugin rpc
+2026.04.30-13:28:58.59 - <debug> Registered op exec_with_resource from plugin rpc
+2026.04.30-13:28:58.60 - <debug> Registered op image_classify from plugin rpc
+2026.04.30-13:28:58.60 - <debug> Registered op image_detect from plugin rpc
+2026.04.30-13:28:58.61 - <debug> Registered op image_segment from plugin rpc
+2026.04.30-13:28:58.62 - <debug> Registered op image_depth from plugin rpc
+2026.04.30-13:28:58.62 - <debug> Registered op image_pose from plugin rpc
+2026.04.30-13:28:58.62 - <debug> Registered op tflite_model_load from plugin rpc
+2026.04.30-13:28:58.62 - <debug> Registered op tflite_model_unload from plugin rpc
+2026.04.30-13:28:58.62 - <debug> Registered op tflite_model_run from plugin rpc
+2026.04.30-13:28:58.63 - <debug> Registered op torch_model_load from plugin rpc
+2026.04.30-13:28:58.63 - <debug> Registered op torch_model_run from plugin rpc
+2026.04.30-13:28:58.63 - <debug> Registered op blas_sgemm from plugin rpc
+2026.04.30-13:28:58.63 - <debug> Registered op fpga_arraycopy from plugin rpc
+2026.04.30-13:28:58.63 - <debug> Registered op fpga_mmult from plugin rpc
+2026.04.30-13:28:58.64 - <debug> Registered op fpga_parallel from plugin rpc
+2026.04.30-13:28:58.64 - <debug> Registered op fpga_vectoradd from plugin rpc
+2026.04.30-13:28:58.64 - <debug> Registered op minmax from plugin rpc
+2026.04.30-13:28:58.64 - <debug> Registered op opencv from plugin rpc
+2026.04.30-13:28:58.64 - <debug> Registered op tf_model_load from plugin rpc
+2026.04.30-13:28:58.64 - <debug> Registered op tf_model_unload from plugin rpc
+2026.04.30-13:28:58.65 - <debug> Registered op tf_model_run from plugin rpc
+2026.04.30-13:28:58.65 - <debug> Loaded plugin rpc from libvaccel-rpc.so
+2026.04.30-13:28:58.65 - <debug> [rpc] Initializing new remote session
+2026.04.30-13:28:58.66 - <debug> [rpc] Initialized remote session 1
+2026.04.30-13:28:58.66 - <debug> New rundir for session 1: /run/user/0/vaccel/6dyxAu/session.1
+2026.04.30-13:28:58.66 - <debug> Initialized session 1 with plugin rpc (remote id: 1)
 Initialized session with id: 1
-2025.04.08-19:34:48.34 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.08-19:34:48.34 - <debug> Returning func from hint plugin rpc
-2025.04.08-19:34:48.34 - <debug> Found implementation in rpc plugin
+2026.04.30-13:28:58.66 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.30-13:28:58.66 - <debug> Returning func for op image_classify from plugin rpc
+2026.04.30-13:28:58.66 - <debug> [rpc] session:1 Executing op image_classify
 classification tags: This is a dummy classification tag!
 classification imagename: This is a dummy imgname!
-2025.04.08-19:34:48.35 - <debug> [rpc] Releasing remote session 1
-2025.04.08-19:34:48.35 - <debug> Released session 1
-2025.04.08-19:34:48.35 - <debug> Cleaning up vAccel
-2025.04.08-19:34:48.35 - <debug> Cleaning up sessions
-2025.04.08-19:34:48.35 - <debug> Cleaning up resources
-2025.04.08-19:34:48.35 - <debug> Cleaning up plugins
-2025.04.08-19:34:48.35 - <debug> Unregistered plugin rpc
+2026.04.30-13:28:58.67 - <debug> [rpc] Releasing remote session 1
+2026.04.30-13:28:58.67 - <debug> Released session 1
+2026.04.30-13:28:58.67 - <debug> Cleaning up vAccel
+2026.04.30-13:28:58.67 - <debug> Cleaning up sessions
+2026.04.30-13:28:58.67 - <debug> Cleaning up resources
+2026.04.30-13:28:58.67 - <debug> Cleaning up plugins
+2026.04.30-13:28:58.67 - <debug> Unregistered plugin rpc
 ```
 
 In the other terminal, where the vAccel RPC agent is running, you should also
 see the corresponding host vAccel output:
 
 ```console
-2025.04.08-19:34:48.36 - <debug> New rundir for session 1: /run/user/1002/vaccel/j1Kwrv/session.1
-2025.04.08-19:34:48.36 - <debug> Initialized session 1
-[2025-04-08T19:34:48Z INFO  vaccel_rpc_agent::session] Created session 1
-[2025-04-08T19:34:48Z INFO  vaccel_rpc_agent::ops::genop] Genop session 1
-2025.04.08-19:34:48.37 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.08-19:34:48.37 - <debug> Returning func from hint plugin noop
-2025.04.08-19:34:48.37 - <debug> Found implementation in noop plugin
-2025.04.08-19:34:48.37 - <debug> [noop] Calling Image classification for session 1
-2025.04.08-19:34:48.37 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.08-19:34:48.37 - <debug> [noop] model: (null)
-2025.04.08-19:34:48.37 - <debug> [noop] len_img: 79281
-2025.04.08-19:34:48.37 - <debug> [noop] len_out_text: 512
-2025.04.08-19:34:48.37 - <debug> [noop] len_out_imgname: 512
-2025.04.08-19:34:48.37 - <debug> [noop] will return a dummy result
-2025.04.08-19:34:48.37 - <debug> [noop] will return a dummy result
-2025.04.08-19:34:48.38 - <debug> Released session 1
-[2025-04-08T19:34:48Z INFO  vaccel_rpc_agent::session] Destroyed session 1
+2026.04.30-13:28:58.76 - <debug> New rundir for session 1: /run/user/0/vaccel/yAuTYA/session.1
+2026.04.30-13:28:58.76 - <debug> Initialized session 1 with plugin noop
+[2026-04-30T13:28:58Z INFO  vaccel_rpc_agent::session] Created session 1
+[2026-04-30T13:28:58Z INFO  vaccel_rpc_agent::ops::genop] session:1 Genop
+2026.04.30-13:28:58.77 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.30-13:28:58.77 - <debug> Returning func for op image_classify from plugin noop
+2026.04.30-13:28:58.77 - <debug> [noop] Calling Image classification for session 1
+2026.04.30-13:28:58.77 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.30-13:28:58.77 - <debug> [noop] model: (null)
+2026.04.30-13:28:58.77 - <debug> [noop] len_img: 79281
+2026.04.30-13:28:58.77 - <debug> [noop] len_out_text: 512
+2026.04.30-13:28:58.77 - <debug> [noop] len_out_imgname: 512
+2026.04.30-13:28:58.77 - <debug> [noop] will return a dummy result
+2026.04.30-13:28:58.77 - <debug> [noop] will return a dummy result
+2026.04.30-13:28:58.78 - <debug> Released session 1
+[2026-04-30T13:28:58Z INFO  vaccel_rpc_agent::session] Destroyed session 1
 ```
 
 If you compare the application output with the
@@ -710,7 +727,7 @@ If you compare the application output with the
 ignoring the vAccel log messages, you will notice that it is identical:
 
 ```console
-# classify /usr/local/share/vaccel/images/example.jpg 1
+# classify /usr/share/vaccel/images/example.jpg 1
 ...
 Initialized session with id: 1
 ...
@@ -724,82 +741,80 @@ plugin is used directly:
 
 ```console
 $ classify /usr/local/share/vaccel/images/example.jpg 1
-2025.04.03-15:44:04.61 - <debug> Initializing vAccel
-2025.04.03-15:44:04.61 - <info> vAccel 0.6.1-194-19056528
-2025.04.03-15:44:04.61 - <debug> Config:
-2025.04.03-15:44:04.61 - <debug>   plugins = libvaccel-noop.so
-2025.04.03-15:44:04.61 - <debug>   log_level = debug
-2025.04.03-15:44:04.61 - <debug>   log_file = (null)
-2025.04.03-15:44:04.61 - <debug>   profiling_enabled = false
-2025.04.03-15:44:04.61 - <debug>   version_ignore = false
-2025.04.03-15:44:04.61 - <debug> Created top-level rundir: /run/user/1002/vaccel/VC0Gxz
-2025.04.03-15:44:04.61 - <info> Registered plugin noop 0.6.1-194-19056528
+2026.04.29-14:47:59.38 - <debug> Initializing vAccel
+2026.04.29-14:47:59.38 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.29-14:47:59.38 - <debug> Config:
+2026.04.29-14:47:59.38 - <debug>   plugins = libvaccel-noop.so
+2026.04.29-14:47:59.38 - <debug>   log_level = debug
+2026.04.29-14:47:59.38 - <debug>   log_file = (null)
+2026.04.29-14:47:59.38 - <debug>   profiling_enabled = false
+2026.04.29-14:47:59.38 - <debug>   version_ignore = false
+2026.04.29-14:47:59.38 - <debug> Created top-level rundir: /run/user/0/vaccel/fPAGh6
+2026.04.29-14:47:59.38 - <info> Registered plugin noop 0.7.1-93-ebc23b1f
 ...
-2025.04.03-15:44:04.61 - <debug> Loaded plugin noop from libvaccel-noop.so
+2026.04.29-14:47:59.38 - <debug> Loaded plugin noop from libvaccel-noop.so
 ...
-2025.04.03-15:44:04.62 - <debug> Returning func from hint plugin noop
-2025.04.03-15:44:04.62 - <debug> Found implementation in noop plugin
-2025.04.03-15:44:04.62 - <debug> [noop] Calling Image classification for session 1
-2025.04.03-15:44:04.62 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.03-15:44:04.62 - <debug> [noop] model: (null)
-2025.04.03-15:44:04.62 - <debug> [noop] len_img: 79281
-2025.04.03-15:44:04.62 - <debug> [noop] len_out_text: 512
-2025.04.03-15:44:04.62 - <debug> [noop] len_out_imgname: 512
-2025.04.03-15:44:04.62 - <debug> [noop] will return a dummy result
-2025.04.03-15:44:04.62 - <debug> [noop] will return a dummy result
+2026.04.29-14:47:59.38 - <debug> Returning func for op image_classify from plugin noop
+2026.04.29-14:47:59.38 - <debug> [noop] Calling Image classification for session 1
+2026.04.29-14:47:59.38 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.29-14:47:59.38 - <debug> [noop] model: (null)
+2026.04.29-14:47:59.38 - <debug> [noop] len_img: 79281
+2026.04.29-14:47:59.38 - <debug> [noop] len_out_text: 512
+2026.04.29-14:47:59.38 - <debug> [noop] len_out_imgname: 512
+2026.04.29-14:47:59.38 - <debug> [noop] will return a dummy result
+2026.04.29-14:47:59.38 - <debug> [noop] will return a dummy result
 ```
 
 whereas in the VM case, the `RPC` plugin is used on the guest:
 
 ```console
-# classify /usr/local/share/vaccel/images/example.jpg 1
-2025.04.08-19:34:48.28 - <debug> Initializing vAccel
-2025.04.08-19:34:48.28 - <info> vAccel 0.6.1-194-19056528
-2025.04.08-19:34:48.28 - <debug> Config:
-2025.04.08-19:34:48.28 - <debug>   plugins = libvaccel-rpc.so
-2025.04.08-19:34:48.28 - <debug>   log_level = debug
-2025.04.08-19:34:48.28 - <debug>   log_file = (null)
-2025.04.08-19:34:48.28 - <debug>   profiling_enabled = false
-2025.04.08-19:34:48.28 - <debug>   version_ignore = false
-2025.04.08-19:34:48.28 - <debug> Created top-level rundir: /run/user/0/vaccel/JE4UiS
-2025.04.08-19:34:48.30 - <info> Registered plugin rpc 0.1.0-36-bbffdae6
+# classify /usr/share/vaccel/images/example.jpg 1
+2026.04.30-13:28:58.56 - <debug> Initializing vAccel
+2026.04.30-13:28:58.57 - <info> vAccel 0.7.1-92-995d8f4c
+2026.04.30-13:28:58.57 - <debug> Config:
+2026.04.30-13:28:58.57 - <debug>   plugins = libvaccel-rpc.so
+2026.04.30-13:28:58.57 - <debug>   log_level = debug
+2026.04.30-13:28:58.57 - <debug>   log_file = (null)
+2026.04.30-13:28:58.57 - <debug>   profiling_enabled = false
+2026.04.30-13:28:58.57 - <debug>   version_ignore = false
+2026.04.30-13:28:58.58 - <debug> Created top-level rundir: /run/user/0/vaccel/6dyxAu
+2026.04.30-13:28:58.59 - <info> Registered plugin rpc 0.2.1-14-9ae931a0
 ...
-2025.04.08-19:34:48.30 - <debug> Loaded plugin rpc from libvaccel-rpc.so
-2025.04.08-19:34:48.31 - <debug> [rpc] Initializing new remote session
-2025.04.08-19:34:48.34 - <debug> [rpc] Initialized remote session 1
+2026.04.30-13:28:58.65 - <debug> Loaded plugin rpc from libvaccel-rpc.so
+2026.04.30-13:28:58.65 - <debug> [rpc] Initializing new remote session
+2026.04.30-13:28:58.66 - <debug> [rpc] Initialized remote session 1
 ...
-2025.04.08-19:34:48.34 - <debug> Returning func from hint plugin rpc
-2025.04.08-19:34:48.34 - <debug> Found implementation in rpc plugin
+2026.04.30-13:28:58.66 - <debug> Returning func for op image_classify from plugin rpc
+2026.04.30-13:28:58.66 - <debug> [rpc] session:1 Executing op image_classify
 ...
-2025.04.08-19:34:48.35 - <debug> [rpc] Releasing remote session 1
+2026.04.30-13:28:58.67 - <debug> [rpc] Releasing remote session 1
 ...
 ```
 
 while the `NoOp` plugin is used on the host:
 
 ```console
-2025.04.08-19:34:05.40 - <debug> Initializing vAccel
-2025.04.08-19:34:05.40 - <info> vAccel 0.6.1-194-19056528
-2025.04.08-19:34:05.40 - <debug> Config:
-2025.04.08-19:34:05.40 - <debug>   plugins = libvaccel-noop.so
-2025.04.08-19:34:05.40 - <debug>   log_level = debug
-2025.04.08-19:34:05.40 - <debug>   log_file = (null)
-2025.04.08-19:34:05.40 - <debug>   profiling_enabled = false
-2025.04.08-19:34:05.40 - <debug>   version_ignore = false
-2025.04.08-19:34:05.40 - <debug> Created top-level rundir: /run/user/1002/vaccel/j1Kwrv
-2025.04.08-19:34:05.40 - <info> Registered plugin noop 0.6.1-194-19056528
+2026.04.30-13:28:36.25 - <debug> Initializing vAccel
+2026.04.30-13:28:36.25 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.30-13:28:36.25 - <debug> Config:
+2026.04.30-13:28:36.25 - <debug>   plugins = libvaccel-noop.so
+2026.04.30-13:28:36.25 - <debug>   log_level = debug
+2026.04.30-13:28:36.25 - <debug>   log_file = (null)
+2026.04.30-13:28:36.25 - <debug>   profiling_enabled = false
+2026.04.30-13:28:36.25 - <debug>   version_ignore = false
+2026.04.30-13:28:36.28 - <debug> Created top-level rundir: /run/user/0/vaccel/yAuTYA
+2026.04.30-13:28:36.28 - <info> Registered plugin noop 0.7.1-93-ebc23b1f
 ...
-2025.04.08-19:34:05.40 - <debug> Loaded plugin noop from libvaccel-noop.so
+2026.04.30-13:28:36.28 - <debug> Loaded plugin noop from libvaccel-noop.so
 ...
-2025.04.08-19:34:48.37 - <debug> Returning func from hint plugin noop
-2025.04.08-19:34:48.37 - <debug> Found implementation in noop plugin
-2025.04.08-19:34:48.37 - <debug> [noop] Calling Image classification for session 1
-2025.04.08-19:34:48.37 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.08-19:34:48.37 - <debug> [noop] model: (null)
-2025.04.08-19:34:48.37 - <debug> [noop] len_img: 79281
-2025.04.08-19:34:48.37 - <debug> [noop] len_out_text: 512
-2025.04.08-19:34:48.37 - <debug> [noop] len_out_imgname: 512
-2025.04.08-19:34:48.37 - <debug> [noop] will return a dummy result
-2025.04.08-19:34:48.37 - <debug> [noop] will return a dummy result
+2026.04.30-13:28:58.77 - <debug> Returning func for op image_classify from plugin noop
+2026.04.30-13:28:58.77 - <debug> [noop] Calling Image classification for session 1
+2026.04.30-13:28:58.77 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.30-13:28:58.77 - <debug> [noop] model: (null)
+2026.04.30-13:28:58.77 - <debug> [noop] len_img: 79281
+2026.04.30-13:28:58.77 - <debug> [noop] len_out_text: 512
+2026.04.30-13:28:58.77 - <debug> [noop] len_out_imgname: 512
+2026.04.30-13:28:58.77 - <debug> [noop] will return a dummy result
+2026.04.30-13:28:58.77 - <debug> [noop] will return a dummy result
 ...
 ```

--- a/docs/tutorials/running-a-vaccel-application-remotely.md
+++ b/docs/tutorials/running-a-vaccel-application-remotely.md
@@ -78,44 +78,45 @@ To start a `vaccel-rpc-agent` with the vAccel `NoOp` plugin use:
 $ VACCEL_BOOTSTRAP_ENABLED=0 vaccel-rpc-agent \
       -a "${VACCEL_RPC_ADDRESS}" \
       --vaccel-config "plugins=libvaccel-noop.so,log_level=4"
-2025.04.07-17:19:53.56 - <debug> Initializing vAccel
-2025.04.07-17:19:53.56 - <info> vAccel 0.6.1-194-19056528
-2025.04.07-17:19:53.56 - <debug> Config:
-2025.04.07-17:19:53.56 - <debug>   plugins = libvaccel-noop.so
-2025.04.07-17:19:53.56 - <debug>   log_level = debug
-2025.04.07-17:19:53.56 - <debug>   log_file = (null)
-2025.04.07-17:19:53.56 - <debug>   profiling_enabled = false
-2025.04.07-17:19:53.56 - <debug>   version_ignore = false
-2025.04.07-17:19:53.56 - <debug> Created top-level rundir: /run/user/1002/vaccel/YvIPeM
-2025.04.07-17:19:53.56 - <info> Registered plugin noop 0.6.1-194-19056528
-2025.04.07-17:19:53.56 - <debug> Registered op noop from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op blas_sgemm from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op image_classify from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op image_detect from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op image_segment from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op image_pose from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op image_depth from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op exec from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op tf_session_load from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op tf_session_run from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op tf_session_delete from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op minmax from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op fpga_arraycopy from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op fpga_vectoradd from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op fpga_parallel from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op fpga_mmult from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op exec_with_resource from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op torch_jitload_forward from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op torch_sgemm from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op opencv from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op tflite_session_load from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op tflite_session_run from plugin noop
-2025.04.07-17:19:53.56 - <debug> Registered op tflite_session_delete from plugin noop
-2025.04.07-17:19:53.56 - <debug> Loaded plugin noop from libvaccel-noop.so
-[2025-04-07T17:19:53Z INFO  ttrpc::sync::server] server listen started
-[2025-04-07T17:19:53Z INFO  ttrpc::sync::server] server started
-[2025-04-07T17:19:53Z INFO  vaccel_rpc_agent] vAccel RPC agent started
-[2025-04-07T17:19:53Z INFO  vaccel_rpc_agent] Listening on 'tcp://0.0.0.0:65500', press Ctrl+C to exit
+2026.04.30-12:42:52.63 - <debug> Initializing vAccel
+2026.04.30-12:42:52.63 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.30-12:42:52.63 - <debug> Config:
+2026.04.30-12:42:52.63 - <debug>   plugins = libvaccel-noop.so
+2026.04.30-12:42:52.63 - <debug>   log_level = debug
+2026.04.30-12:42:52.63 - <debug>   log_file = (null)
+2026.04.30-12:42:52.63 - <debug>   profiling_enabled = false
+2026.04.30-12:42:52.63 - <debug>   version_ignore = false
+2026.04.30-12:42:52.63 - <debug> Created top-level rundir: /run/user/0/vaccel/Mr4v2I
+2026.04.30-12:42:52.63 - <info> Registered plugin noop 0.7.1-93-ebc23b1f
+2026.04.30-12:42:52.63 - <debug> Registered op noop from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op exec from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op exec_with_resource from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op image_classify from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op image_detect from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op image_segment from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op image_pose from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op image_depth from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op tf_model_load from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op tf_model_unload from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op tf_model_run from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op tflite_model_load from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op tflite_model_unload from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op tflite_model_run from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op torch_model_load from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op torch_model_run from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op torch_sgemm from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op blas_sgemm from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op fpga_arraycopy from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op fpga_vectoradd from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op fpga_parallel from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op fpga_mmult from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op minmax from plugin noop
+2026.04.30-12:42:52.63 - <debug> Registered op opencv from plugin noop
+2026.04.30-12:42:52.63 - <debug> Loaded plugin noop from libvaccel-noop.so
+[2026-04-30T12:42:52Z INFO  ttrpc::sync::server] server listen started
+[2026-04-30T12:42:52Z INFO  ttrpc::sync::server] server started
+[2026-04-30T12:42:52Z INFO  vaccel_rpc_agent] vAccel RPC agent started
+[2026-04-30T12:42:52Z INFO  vaccel_rpc_agent] Listening on 'tcp://0.0.0.0:65500', press Ctrl+C to exit
 ```
 
 ## Running the application on the remote host
@@ -149,79 +150,79 @@ Finally, you can run an image classification example with:
 
 ```console
 $ classify /usr/local/share/vaccel/images/example.jpg 1
-2025.04.07-17:23:51.51 - <debug> Initializing vAccel
-2025.04.07-17:23:51.51 - <info> vAccel 0.6.1-194-19056528
-2025.04.07-17:23:51.51 - <debug> Config:
-2025.04.07-17:23:51.51 - <debug>   plugins = /usr/local/lib/x86_64-linux-gnu/libvaccel-rpc.so
-2025.04.07-17:23:51.51 - <debug>   log_level = debug
-2025.04.07-17:23:51.51 - <debug>   log_file = (null)
-2025.04.07-17:23:51.51 - <debug>   profiling_enabled = false
-2025.04.07-17:23:51.51 - <debug>   version_ignore = false
-2025.04.07-17:23:51.51 - <debug> Created top-level rundir: /run/user/1002/vaccel/2Qc6ZB
-2025.04.07-17:23:51.51 - <info> Registered plugin rpc 0.1.0-36-bbffdae6
-2025.04.07-17:23:51.51 - <debug> rpc is a VirtIO module
-2025.04.07-17:23:51.51 - <debug> Registered op blas_sgemm from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op image_classify from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op image_detect from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op image_segment from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op image_depth from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op image_pose from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op tflite_session_load from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op tflite_session_delete from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op tflite_session_run from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op minmax from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op fpga_arraycopy from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op fpga_mmult from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op fpga_vectoradd from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op fpga_parallel from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op exec from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op exec_with_resource from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op torch_jitload_forward from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op opencv from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op tf_session_load from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op tf_session_delete from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Registered op tf_session_run from plugin rpc
-2025.04.07-17:23:51.51 - <debug> Loaded plugin rpc from /usr/local/lib/x86_64-linux-gnu/libvaccel-rpc.so
-2025.04.07-17:23:51.51 - <debug> [rpc] Initializing new remote session
-2025.04.07-17:23:51.51 - <debug> [rpc] Initialized remote session 1
-2025.04.07-17:23:51.51 - <debug> New rundir for session 1: /run/user/1002/vaccel/2Qc6ZB/session.1
-2025.04.07-17:23:51.51 - <debug> Initialized session 1 with remote (id: 1)
+2026.04.30-12:43:15.51 - <debug> Initializing vAccel
+2026.04.30-12:43:15.51 - <info> vAccel 0.7.1-93-ebc23b1f
+2026.04.30-12:43:15.51 - <debug> Config:
+2026.04.30-12:43:15.51 - <debug>   plugins = /usr/local/lib/x86_64-linux-gnu/libvaccel-rpc.so
+2026.04.30-12:43:15.51 - <debug>   log_level = debug
+2026.04.30-12:43:15.51 - <debug>   log_file = (null)
+2026.04.30-12:43:15.51 - <debug>   profiling_enabled = false
+2026.04.30-12:43:15.51 - <debug>   version_ignore = false
+2026.04.30-12:43:15.51 - <debug> Created top-level rundir: /run/user/0/vaccel/fdfPJq
+2026.04.30-12:43:15.51 - <info> Registered plugin rpc 0.2.1-21-e08235e7
+2026.04.30-12:43:15.51 - <debug> rpc is a VirtIO module
+2026.04.30-12:43:15.51 - <debug> Registered op exec from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op exec_with_resource from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op image_classify from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op image_detect from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op image_segment from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op image_depth from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op image_pose from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op tflite_model_load from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op tflite_model_unload from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op tflite_model_run from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op torch_model_load from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op torch_model_run from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op blas_sgemm from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op fpga_arraycopy from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op fpga_mmult from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op fpga_parallel from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op fpga_vectoradd from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op minmax from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op opencv from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op tf_model_load from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op tf_model_unload from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Registered op tf_model_run from plugin rpc
+2026.04.30-12:43:15.51 - <debug> Loaded plugin rpc from /usr/local/lib/x86_64-linux-gnu/libvaccel-rpc.so
+2026.04.30-12:43:15.51 - <debug> [rpc] Initializing new remote session
+2026.04.30-12:43:15.51 - <debug> [rpc] Initialized remote session 1
+2026.04.30-12:43:15.51 - <debug> New rundir for session 1: /run/user/0/vaccel/fdfPJq/session.1
+2026.04.30-12:43:15.51 - <debug> Initialized session 1 with plugin rpc (remote id: 1)
 Initialized session with id: 1
-2025.04.07-17:23:51.51 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.07-17:23:51.51 - <debug> Returning func from hint plugin rpc
-2025.04.07-17:23:51.51 - <debug> Found implementation in rpc plugin
+2026.04.30-12:43:15.51 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.30-12:43:15.51 - <debug> Returning func for op image_classify from plugin rpc
+2026.04.30-12:43:15.51 - <debug> [rpc] session:1 Executing op image_classify
 classification tags: This is a dummy classification tag!
 classification imagename: This is a dummy imgname!
-2025.04.07-17:23:51.55 - <debug> [rpc] Releasing remote session 1
-2025.04.07-17:23:51.64 - <debug> Released session 1
-2025.04.07-17:23:51.64 - <debug> Cleaning up vAccel
-2025.04.07-17:23:51.64 - <debug> Cleaning up sessions
-2025.04.07-17:23:51.64 - <debug> Cleaning up resources
-2025.04.07-17:23:51.64 - <debug> Cleaning up plugins
-2025.04.07-17:23:51.64 - <debug> Unregistered plugin rpc
+2026.04.30-12:43:15.55 - <debug> [rpc] Releasing remote session 1
+2026.04.30-12:43:15.64 - <debug> Released session 1
+2026.04.30-12:43:15.64 - <debug> Cleaning up vAccel
+2026.04.30-12:43:15.64 - <debug> Cleaning up sessions
+2026.04.30-12:43:15.64 - <debug> Cleaning up resources
+2026.04.30-12:43:15.64 - <debug> Cleaning up plugins
+2026.04.30-12:43:15.64 - <debug> Unregistered plugin rpc
 ```
 
 In the host terminal, where the vAccel RPC agent is running, you should also see
 the corresponding host vAccel output:
 
 ```console
-2025.04.07-17:23:51.51 - <debug> New rundir for session 1: /run/user/1002/vaccel/YvIPeM/session.1
-2025.04.07-17:23:51.51 - <debug> Initialized session 1
-[2025-04-07T17:23:51Z INFO  vaccel_rpc_agent::session] Created session 1
-[2025-04-07T17:23:51Z INFO  vaccel_rpc_agent::ops::genop] Genop session 1
-2025.04.07-17:23:51.51 - <debug> session:1 Looking for plugin implementing VACCEL_OP_IMAGE_CLASSIFY
-2025.04.07-17:23:51.51 - <debug> Returning func from hint plugin noop
-2025.04.07-17:23:51.51 - <debug> Found implementation in noop plugin
-2025.04.07-17:23:51.51 - <debug> [noop] Calling Image classification for session 1
-2025.04.07-17:23:51.51 - <debug> [noop] Dumping arguments for Image classification:
-2025.04.07-17:23:51.51 - <debug> [noop] model: (null)
-2025.04.07-17:23:51.51 - <debug> [noop] len_img: 79281
-2025.04.07-17:23:51.51 - <debug> [noop] len_out_text: 512
-2025.04.07-17:23:51.51 - <debug> [noop] len_out_imgname: 512
-2025.04.07-17:23:51.51 - <debug> [noop] will return a dummy result
-2025.04.07-17:23:51.51 - <debug> [noop] will return a dummy result
-2025.04.07-17:23:51.60 - <debug> Released session 1
-[2025-04-07T17:23:51Z INFO  vaccel_rpc_agent::session] Destroyed session 1
+2026.04.30-12:43:15.51 - <debug> New rundir for session 1: /run/user/0/vaccel/Mr4v2I/session.1
+2026.04.30-12:43:15.51 - <debug> Initialized session 1 with plugin noop
+[2026-04-30T12:43:15Z INFO  vaccel_rpc_agent::session] Created session 1
+[2026-04-30T12:43:15Z INFO  vaccel_rpc_agent::ops::genop] session:1 Genop
+2026.04.30-12:43:15.51 - <debug> session:1 Looking for func implementing op image_classify
+2026.04.30-12:43:15.51 - <debug> Returning func for op image_classify from plugin noop
+2026.04.30-12:43:15.51 - <debug> [noop] Calling Image classification for session 1
+2026.04.30-12:43:15.51 - <debug> [noop] Dumping arguments for Image classification:
+2026.04.30-12:43:15.51 - <debug> [noop] model: (null)
+2026.04.30-12:43:15.51 - <debug> [noop] len_img: 79281
+2026.04.30-12:43:15.51 - <debug> [noop] len_out_text: 512
+2026.04.30-12:43:15.51 - <debug> [noop] len_out_imgname: 512
+2026.04.30-12:43:15.51 - <debug> [noop] will return a dummy result
+2026.04.30-12:43:15.51 - <debug> [noop] will return a dummy result
+2026.04.30-12:43:15.59 - <debug> Released session 1
+[2026-04-30T12:43:15Z INFO  vaccel_rpc_agent::session] Destroyed session 1
 ```
 
 If you compare the application output with the

--- a/docs/useful-docs/build-and-install-pytorch.md
+++ b/docs/useful-docs/build-and-install-pytorch.md
@@ -14,7 +14,7 @@ required dependencies are already installed.
 Clone the PyTorch repo, adjusting `TORCH_VERSION` to the desired version:
 
 ```sh
-TORCH_VERSION=2.6.0
+TORCH_VERSION=v2.7.1
 git clone https://github.com/pytorch/pytorch --depth 1 --recursive \
     -b "${TORCH_VERSION}"
 cd pytorch
@@ -39,20 +39,20 @@ cmake --install build --prefix=/usr/local
 
 ## [Alternative] Install pre-built PyTorch C++ API files (LibTorch)
 
-PyTorch provides pre-built binaries for LibTorch. Ie. for version 2.6.0:
+PyTorch provides pre-built binaries for LibTorch. Ie. for version 2.7.1:
 
 Download and extract CPU-only binaries:
 
 ```sh
-wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.6.0%2Bcpu.zip
-unzip libtorch-cxx11-abi-shared-with-deps-2.6.0+cpu.zip
+wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.7.1%2Bcpu.zip
+unzip libtorch-cxx11-abi-shared-with-deps-2.7.1+cpu.zip
 ```
 
-or download and extract binaries with CUDA support (here for CUDA 11.8):
+or download and extract binaries with CUDA support (here for CUDA 12.6):
 
 ```sh
-wget https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.6.0%2Bcu118.zip
-unzip libtorch-cxx11-abi-shared-with-deps-2.6.0+cu118.zip
+wget https://download.pytorch.org/libtorch/cu126/libtorch-cxx11-abi-shared-with-deps-2.7.1%2Bcu126.zip
+unzip libtorch-cxx11-abi-shared-with-deps-2.7.1+cu126.zip
 ```
 
 and move files to the desired installation directory:


### PR DESCRIPTION
## Summary

- **Refresh runtime-bearing code blocks** against current `main` artifacts for v0.8.0 - bundled plugins, TF/Torch/TVM acceleration plugins, RPC + virtio transport plugins, language/framework bindings, and the remote / VM / Kubernetes tutorials; rust-bindings example updated to the current `vaccel-rust` API.
- **virtio-plugin: add Torch ops to supported list** - update the supported ops list with what the current plugin exposes.
- **build-and-install-pytorch: pin to runner-image PyTorch version** - align build instructions with the version baked into the runner image used in the CI.

### Notable behavior changes captured

- Op renames in the runtime: `tf_session_*` → `tf_model_*`, `torch_jitload_forward` → `torch_model_load` + `torch_model_run`, `Looking for plugin implementing X` → `Looking for func implementing op X`.
- The latest VirtIO VM rootfs installs vAccel at `/usr` instead of `/usr/local`